### PR TITLE
Automate and align with upstream release cycle

### DIFF
--- a/.github/workflows/update-upstream-provider.yml
+++ b/.github/workflows/update-upstream-provider.yml
@@ -137,6 +137,8 @@ jobs:
         - "3.7"
 name: Update upstream provider
 on:
+  schedule:
+    - cron: '0 17 * * FRI'
   workflow_dispatch:
     inputs:
       linked_issue_number:


### PR DESCRIPTION
Databricks Terraform provider has more or less established schedule. Would be great if pulumi picks it up, so that we could consider this integration active.