### PR TITLE
remove logo  url

### DIFF
--- a/provider/cmd/pulumi-resource-databricks/schema.json
+++ b/provider/cmd/pulumi-resource-databricks/schema.json
@@ -11,7 +11,7 @@
     "license": "Apache-2.0",
     "attribution": "This Pulumi package is based on the [`databricks` Terraform Provider](https://github.com/databricks/terraform-provider-databricks).",
     "repository": "https://github.com/pulumi/pulumi-databricks",
-    "logoUrl": "https://databricks.com/wp-content/uploads/2021/10/db-nav-logo.svg",
+    "logoUrl": "",
     "publisher": "Pulumi",
     "meta": {
         "moduleFormat": "(.*)(?:/[^/]*)"


### PR DESCRIPTION
this is removing the logo url so we can use the logo that's in hugo
this logo is their horizontal word mark which better fills the space
https://github.com/pulumi/pulumi-hugo/blob/master/themes/default/static/logos/pkg/databricks.svg

after this change a release is needed for registry to pick it up