### PR TITLE
Fix panic in useragent.WithUserAgentExtra

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -19,6 +19,7 @@ import (
 	_ "embed"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/databricks/databricks-sdk-go/useragent"
 	databricksProv "github.com/databricks/terraform-provider-databricks/provider"
@@ -41,10 +42,15 @@ const (
 	mainMod = "index" // the databricks module
 )
 
+// Remove a preceding v from a version string to pass the regex checks on WithUserAgentExtra
+func userAgentValue(version string) string {
+	return strings.TrimPrefix(version, "v")
+}
+
 // Provider returns additional overlaid schema and metadata associated with the provider..
 func Provider() tfbridge.ProviderInfo {
 	// Set the user agent to the provider version, this is not the version of the Pulumi CLI.
-	useragent.WithUserAgentExtra("pulumi", version.Version)
+	useragent.WithUserAgentExtra("pulumi", userAgentValue(version.Version))
 	// Instantiate the Terraform provider
 	p := shimv2.NewProvider(databricksProv.DatabricksProvider())
 

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -1,0 +1,54 @@
+// Copyright 2016-2023, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package databricks
+
+import (
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/useragent"
+)
+
+func TestWithUserAgent(t *testing.T) {
+	type testCase struct {
+		name    string
+		version string
+	}
+	testCases := []testCase{
+		{
+			name:    "release",
+			version: "v1.16.0",
+		},
+		{
+			name:    "prerelease",
+			version: "v1.16.0-alpha.1684965741+892cfc57.dirty",
+		},
+		{
+			name:    "release-without-v",
+			version: "1.16.0",
+		},
+		{
+			name:    "prerelease-without-v",
+			version: "1.16.0-alpha.1684965741+892cfc57.dirty",
+		},
+	}
+
+	for _, v := range testCases {
+		t.Run(v.name, func(t *testing.T) {
+			// This function panics when the user agent does not conform to a regular expression checks.
+			useragent.WithUserAgentExtra("pulumi", userAgentValue(v.version))
+			// No error return value to check.
+		})
+	}
+}


### PR DESCRIPTION
Fixes #135

The upstream `useragent` library panics when receiving a semver beginning with "v". This call to `useragent` was added in #134 to address requests that we pass a Pulumi user agent.

This panic was missed by testing due to pulumi/pulumi#12981, panics in a provider during ProgramTest result in an erroneous passing result.

Tracing the source of the panic, we see `useragent.WithUserAgentExtra` calls data.With here.

https://github.com/databricks/databricks-sdk-go/blob/v0.9.0/useragent/user_agent.go#L42-L46
```go
// WithUserAgentExtra sets per-process extra user agent data,
// which integration developers have agreed with Databricks.
func WithUserAgentExtra(key, value string) {
	extra = extra.With(key, value)
}
```

The `With` method then performs two checks, and if either fails it panics:

https://github.com/databricks/databricks-sdk-go/blob/v0.9.0/useragent/user_agent.go#L88-L96
```
// With always uses the latest value for a given alphanumeric key.
// Panics if key or value don't satisfy alphanumeric or semver format.
func (d data) With(key, value string) data {
  if err := matchAlphanum(key); err != nil {
    panic(err)
  }
  if err := matchAlphanumOrSemVer(value); err != nil {
    panic(err)
  }
  // ...
}
```