### PR TITLE
[Breaking] Set workspace_id to a string instead of int for Pulumi

### DIFF
--- a/provider/cmd/pulumi-resource-databricks/bridge-metadata.json
+++ b/provider/cmd/pulumi-resource-databricks/bridge-metadata.json
@@ -6752,5 +6752,24 @@
             "skipVerify": "skip_verify",
             "warehouseId": "warehouse_id"
         }
+    },
+    "workspace-id": {
+        "resources": {
+            "databricks_catalog_workspace_binding": [
+                "workspace_id"
+            ],
+            "databricks_metastore_assignment": [
+                "workspace_id"
+            ],
+            "databricks_mws_networks": [
+                "workspace_id"
+            ],
+            "databricks_mws_permission_assignment": [
+                "workspace_id"
+            ],
+            "databricks_mws_workspaces": [
+                "workspace_id"
+            ]
+        }
     }
 }

--- a/provider/cmd/pulumi-resource-databricks/schema.json
+++ b/provider/cmd/pulumi-resource-databricks/schema.json
@@ -13878,7 +13878,7 @@
                     "description": "Type of securable. Default to `catalog`. Change forces creation of a new resource.\n"
                 },
                 "workspaceId": {
-                    "type": "integer",
+                    "type": "string",
                     "description": "ID of the workspace. Change forces creation of a new resource.\n"
                 }
             },
@@ -13904,7 +13904,7 @@
                     "willReplaceOnChanges": true
                 },
                 "workspaceId": {
-                    "type": "integer",
+                    "type": "string",
                     "description": "ID of the workspace. Change forces creation of a new resource.\n",
                     "willReplaceOnChanges": true
                 }
@@ -13933,7 +13933,7 @@
                         "willReplaceOnChanges": true
                     },
                     "workspaceId": {
-                        "type": "integer",
+                        "type": "string",
                         "description": "ID of the workspace. Change forces creation of a new resource.\n",
                         "willReplaceOnChanges": true
                     }
@@ -17508,7 +17508,7 @@
                     "description": "Unique identifier of the parent Metastore\n"
                 },
                 "workspaceId": {
-                    "type": "integer",
+                    "type": "string",
                     "description": "id of the workspace for the assignment\n"
                 }
             },
@@ -17527,7 +17527,7 @@
                     "willReplaceOnChanges": true
                 },
                 "workspaceId": {
-                    "type": "integer",
+                    "type": "string",
                     "description": "id of the workspace for the assignment\n",
                     "willReplaceOnChanges": true
                 }
@@ -17549,7 +17549,7 @@
                         "willReplaceOnChanges": true
                     },
                     "workspaceId": {
-                        "type": "integer",
+                        "type": "string",
                         "description": "id of the workspace for the assignment\n",
                         "willReplaceOnChanges": true
                     }
@@ -18765,7 +18765,7 @@
                     "description": "(String) VPC attachment status\n"
                 },
                 "workspaceId": {
-                    "type": "integer",
+                    "type": "string",
                     "description": "(Integer) id of associated workspace\n"
                 }
             },
@@ -18840,7 +18840,7 @@
                     "description": "(String) VPC attachment status\n"
                 },
                 "workspaceId": {
-                    "type": "integer",
+                    "type": "string",
                     "description": "(Integer) id of associated workspace\n"
                 }
             },
@@ -18911,7 +18911,7 @@
                         "description": "(String) VPC attachment status\n"
                     },
                     "workspaceId": {
-                        "type": "integer",
+                        "type": "string",
                         "description": "(Integer) id of associated workspace\n"
                     }
                 },
@@ -18933,7 +18933,7 @@
                     "description": "Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, databricks.ServicePrincipal or databricks.Group data sources.\n"
                 },
                 "workspaceId": {
-                    "type": "integer",
+                    "type": "string",
                     "description": "Databricks workspace ID.\n"
                 }
             },
@@ -18957,7 +18957,7 @@
                     "willReplaceOnChanges": true
                 },
                 "workspaceId": {
-                    "type": "integer",
+                    "type": "string",
                     "description": "Databricks workspace ID.\n",
                     "willReplaceOnChanges": true
                 }
@@ -18984,7 +18984,7 @@
                         "willReplaceOnChanges": true
                     },
                     "workspaceId": {
-                        "type": "integer",
+                        "type": "string",
                         "description": "Databricks workspace ID.\n",
                         "willReplaceOnChanges": true
                     }
@@ -19417,7 +19417,7 @@
                     "$ref": "#/types/databricks:index/MwsWorkspacesToken:MwsWorkspacesToken"
                 },
                 "workspaceId": {
-                    "type": "integer",
+                    "type": "string",
                     "description": "(String) workspace id\n"
                 },
                 "workspaceName": {
@@ -19543,7 +19543,7 @@
                     "$ref": "#/types/databricks:index/MwsWorkspacesToken:MwsWorkspacesToken"
                 },
                 "workspaceId": {
-                    "type": "integer",
+                    "type": "string",
                     "description": "(String) workspace id\n"
                 },
                 "workspaceName": {
@@ -19665,7 +19665,7 @@
                         "$ref": "#/types/databricks:index/MwsWorkspacesToken:MwsWorkspacesToken"
                     },
                     "workspaceId": {
-                        "type": "integer",
+                        "type": "string",
                         "description": "(String) workspace id\n"
                     },
                     "workspaceName": {

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -57,7 +57,7 @@ func userAgentValue(version string) string {
 // string.
 //
 // The bridge converts it back to an int at runtime.
-func setWorkspaceIdToString(p tfbridge.PropertyVisitInfo) (tfbridge.PropertyVisitResult, error) {
+func setWorkspaceIDToString(p tfbridge.PropertyVisitInfo) (tfbridge.PropertyVisitResult, error) {
 	path := p.SchemaPath()
 	attr, ok := path[len(path)-1].(walk.GetAttrStep)
 	if !ok || attr.Name != "workspace_id" {
@@ -180,7 +180,7 @@ func Provider() tfbridge.ProviderInfo {
 		mainMod, tokens.MakeStandard(mainPkg)))
 
 	prov.SetAutonaming(255, "-")
-	tfbridge.MustTraverseProperties(&prov, "workspace-id", setWorkspaceIdToString)
+	tfbridge.MustTraverseProperties(&prov, "workspace-id", setWorkspaceIDToString)
 
 	prov.MustApplyAutoAliases()
 

--- a/provider/resources_test.go
+++ b/provider/resources_test.go
@@ -45,7 +45,7 @@ func TestWithUserAgent(t *testing.T) {
 	}
 
 	for _, v := range testCases {
-		t.Run(v.name, func(t *testing.T) {
+		t.Run(v.name, func(*testing.T) {
 			// This function panics when the user agent does not conform to a regular expression checks.
 			useragent.WithUserAgentExtra("pulumi", userAgentValue(v.version))
 			// No error return value to check.

--- a/sdk/dotnet/CatalogWorkspaceBinding.cs
+++ b/sdk/dotnet/CatalogWorkspaceBinding.cs
@@ -71,7 +71,7 @@ namespace Pulumi.Databricks
         /// ID of the workspace. Change forces creation of a new resource.
         /// </summary>
         [Output("workspaceId")]
-        public Output<int?> WorkspaceId { get; private set; } = null!;
+        public Output<string?> WorkspaceId { get; private set; } = null!;
 
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace Pulumi.Databricks
         /// ID of the workspace. Change forces creation of a new resource.
         /// </summary>
         [Input("workspaceId")]
-        public Input<int>? WorkspaceId { get; set; }
+        public Input<string>? WorkspaceId { get; set; }
 
         public CatalogWorkspaceBindingArgs()
         {
@@ -179,7 +179,7 @@ namespace Pulumi.Databricks
         /// ID of the workspace. Change forces creation of a new resource.
         /// </summary>
         [Input("workspaceId")]
-        public Input<int>? WorkspaceId { get; set; }
+        public Input<string>? WorkspaceId { get; set; }
 
         public CatalogWorkspaceBindingState()
         {

--- a/sdk/dotnet/MetastoreAssignment.cs
+++ b/sdk/dotnet/MetastoreAssignment.cs
@@ -71,7 +71,7 @@ namespace Pulumi.Databricks
         /// id of the workspace for the assignment
         /// </summary>
         [Output("workspaceId")]
-        public Output<int> WorkspaceId { get; private set; } = null!;
+        public Output<string> WorkspaceId { get; private set; } = null!;
 
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace Pulumi.Databricks
         /// id of the workspace for the assignment
         /// </summary>
         [Input("workspaceId", required: true)]
-        public Input<int> WorkspaceId { get; set; } = null!;
+        public Input<string> WorkspaceId { get; set; } = null!;
 
         public MetastoreAssignmentArgs()
         {
@@ -161,7 +161,7 @@ namespace Pulumi.Databricks
         /// id of the workspace for the assignment
         /// </summary>
         [Input("workspaceId")]
-        public Input<int>? WorkspaceId { get; set; }
+        public Input<string>? WorkspaceId { get; set; }
 
         public MetastoreAssignmentState()
         {

--- a/sdk/dotnet/MwsNetworks.cs
+++ b/sdk/dotnet/MwsNetworks.cs
@@ -151,7 +151,7 @@ namespace Pulumi.Databricks
         /// (Integer) id of associated workspace
         /// </summary>
         [Output("workspaceId")]
-        public Output<int> WorkspaceId { get; private set; } = null!;
+        public Output<string> WorkspaceId { get; private set; } = null!;
 
 
         /// <summary>
@@ -294,7 +294,7 @@ namespace Pulumi.Databricks
         /// (Integer) id of associated workspace
         /// </summary>
         [Input("workspaceId")]
-        public Input<int>? WorkspaceId { get; set; }
+        public Input<string>? WorkspaceId { get; set; }
 
         public MwsNetworksArgs()
         {
@@ -395,7 +395,7 @@ namespace Pulumi.Databricks
         /// (Integer) id of associated workspace
         /// </summary>
         [Input("workspaceId")]
-        public Input<int>? WorkspaceId { get; set; }
+        public Input<string>? WorkspaceId { get; set; }
 
         public MwsNetworksState()
         {

--- a/sdk/dotnet/MwsPermissionAssignment.cs
+++ b/sdk/dotnet/MwsPermissionAssignment.cs
@@ -138,7 +138,7 @@ namespace Pulumi.Databricks
         /// Databricks workspace ID.
         /// </summary>
         [Output("workspaceId")]
-        public Output<int> WorkspaceId { get; private set; } = null!;
+        public Output<string> WorkspaceId { get; private set; } = null!;
 
 
         /// <summary>
@@ -210,7 +210,7 @@ namespace Pulumi.Databricks
         /// Databricks workspace ID.
         /// </summary>
         [Input("workspaceId", required: true)]
-        public Input<int> WorkspaceId { get; set; } = null!;
+        public Input<string> WorkspaceId { get; set; } = null!;
 
         public MwsPermissionAssignmentArgs()
         {
@@ -244,7 +244,7 @@ namespace Pulumi.Databricks
         /// Databricks workspace ID.
         /// </summary>
         [Input("workspaceId")]
-        public Input<int>? WorkspaceId { get; set; }
+        public Input<string>? WorkspaceId { get; set; }
 
         public MwsPermissionAssignmentState()
         {

--- a/sdk/dotnet/MwsWorkspaces.cs
+++ b/sdk/dotnet/MwsWorkspaces.cs
@@ -410,7 +410,7 @@ namespace Pulumi.Databricks
         /// (String) workspace id
         /// </summary>
         [Output("workspaceId")]
-        public Output<int> WorkspaceId { get; private set; } = null!;
+        public Output<string> WorkspaceId { get; private set; } = null!;
 
         /// <summary>
         /// name of the workspace, will appear on UI.
@@ -611,7 +611,7 @@ namespace Pulumi.Databricks
         /// (String) workspace id
         /// </summary>
         [Input("workspaceId")]
-        public Input<int>? WorkspaceId { get; set; }
+        public Input<string>? WorkspaceId { get; set; }
 
         /// <summary>
         /// name of the workspace, will appear on UI.
@@ -770,7 +770,7 @@ namespace Pulumi.Databricks
         /// (String) workspace id
         /// </summary>
         [Input("workspaceId")]
-        public Input<int>? WorkspaceId { get; set; }
+        public Input<string>? WorkspaceId { get; set; }
 
         /// <summary>
         /// name of the workspace, will appear on UI.

--- a/sdk/go/databricks/catalogWorkspaceBinding.go
+++ b/sdk/go/databricks/catalogWorkspaceBinding.go
@@ -64,7 +64,7 @@ type CatalogWorkspaceBinding struct {
 	// Type of securable. Default to `catalog`. Change forces creation of a new resource.
 	SecurableType pulumi.StringPtrOutput `pulumi:"securableType"`
 	// ID of the workspace. Change forces creation of a new resource.
-	WorkspaceId pulumi.IntPtrOutput `pulumi:"workspaceId"`
+	WorkspaceId pulumi.StringPtrOutput `pulumi:"workspaceId"`
 }
 
 // NewCatalogWorkspaceBinding registers a new resource with the given unique name, arguments, and options.
@@ -106,7 +106,7 @@ type catalogWorkspaceBindingState struct {
 	// Type of securable. Default to `catalog`. Change forces creation of a new resource.
 	SecurableType *string `pulumi:"securableType"`
 	// ID of the workspace. Change forces creation of a new resource.
-	WorkspaceId *int `pulumi:"workspaceId"`
+	WorkspaceId *string `pulumi:"workspaceId"`
 }
 
 type CatalogWorkspaceBindingState struct {
@@ -119,7 +119,7 @@ type CatalogWorkspaceBindingState struct {
 	// Type of securable. Default to `catalog`. Change forces creation of a new resource.
 	SecurableType pulumi.StringPtrInput
 	// ID of the workspace. Change forces creation of a new resource.
-	WorkspaceId pulumi.IntPtrInput
+	WorkspaceId pulumi.StringPtrInput
 }
 
 func (CatalogWorkspaceBindingState) ElementType() reflect.Type {
@@ -136,7 +136,7 @@ type catalogWorkspaceBindingArgs struct {
 	// Type of securable. Default to `catalog`. Change forces creation of a new resource.
 	SecurableType *string `pulumi:"securableType"`
 	// ID of the workspace. Change forces creation of a new resource.
-	WorkspaceId *int `pulumi:"workspaceId"`
+	WorkspaceId *string `pulumi:"workspaceId"`
 }
 
 // The set of arguments for constructing a CatalogWorkspaceBinding resource.
@@ -150,7 +150,7 @@ type CatalogWorkspaceBindingArgs struct {
 	// Type of securable. Default to `catalog`. Change forces creation of a new resource.
 	SecurableType pulumi.StringPtrInput
 	// ID of the workspace. Change forces creation of a new resource.
-	WorkspaceId pulumi.IntPtrInput
+	WorkspaceId pulumi.StringPtrInput
 }
 
 func (CatalogWorkspaceBindingArgs) ElementType() reflect.Type {
@@ -261,8 +261,8 @@ func (o CatalogWorkspaceBindingOutput) SecurableType() pulumi.StringPtrOutput {
 }
 
 // ID of the workspace. Change forces creation of a new resource.
-func (o CatalogWorkspaceBindingOutput) WorkspaceId() pulumi.IntPtrOutput {
-	return o.ApplyT(func(v *CatalogWorkspaceBinding) pulumi.IntPtrOutput { return v.WorkspaceId }).(pulumi.IntPtrOutput)
+func (o CatalogWorkspaceBindingOutput) WorkspaceId() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *CatalogWorkspaceBinding) pulumi.StringPtrOutput { return v.WorkspaceId }).(pulumi.StringPtrOutput)
 }
 
 type CatalogWorkspaceBindingArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/databricks/metastoreAssignment.go
+++ b/sdk/go/databricks/metastoreAssignment.go
@@ -72,7 +72,7 @@ type MetastoreAssignment struct {
 	// Unique identifier of the parent Metastore
 	MetastoreId pulumi.StringOutput `pulumi:"metastoreId"`
 	// id of the workspace for the assignment
-	WorkspaceId pulumi.IntOutput `pulumi:"workspaceId"`
+	WorkspaceId pulumi.StringOutput `pulumi:"workspaceId"`
 }
 
 // NewMetastoreAssignment registers a new resource with the given unique name, arguments, and options.
@@ -116,7 +116,7 @@ type metastoreAssignmentState struct {
 	// Unique identifier of the parent Metastore
 	MetastoreId *string `pulumi:"metastoreId"`
 	// id of the workspace for the assignment
-	WorkspaceId *int `pulumi:"workspaceId"`
+	WorkspaceId *string `pulumi:"workspaceId"`
 }
 
 type MetastoreAssignmentState struct {
@@ -125,7 +125,7 @@ type MetastoreAssignmentState struct {
 	// Unique identifier of the parent Metastore
 	MetastoreId pulumi.StringPtrInput
 	// id of the workspace for the assignment
-	WorkspaceId pulumi.IntPtrInput
+	WorkspaceId pulumi.StringPtrInput
 }
 
 func (MetastoreAssignmentState) ElementType() reflect.Type {
@@ -138,7 +138,7 @@ type metastoreAssignmentArgs struct {
 	// Unique identifier of the parent Metastore
 	MetastoreId string `pulumi:"metastoreId"`
 	// id of the workspace for the assignment
-	WorkspaceId int `pulumi:"workspaceId"`
+	WorkspaceId string `pulumi:"workspaceId"`
 }
 
 // The set of arguments for constructing a MetastoreAssignment resource.
@@ -148,7 +148,7 @@ type MetastoreAssignmentArgs struct {
 	// Unique identifier of the parent Metastore
 	MetastoreId pulumi.StringInput
 	// id of the workspace for the assignment
-	WorkspaceId pulumi.IntInput
+	WorkspaceId pulumi.StringInput
 }
 
 func (MetastoreAssignmentArgs) ElementType() reflect.Type {
@@ -249,8 +249,8 @@ func (o MetastoreAssignmentOutput) MetastoreId() pulumi.StringOutput {
 }
 
 // id of the workspace for the assignment
-func (o MetastoreAssignmentOutput) WorkspaceId() pulumi.IntOutput {
-	return o.ApplyT(func(v *MetastoreAssignment) pulumi.IntOutput { return v.WorkspaceId }).(pulumi.IntOutput)
+func (o MetastoreAssignmentOutput) WorkspaceId() pulumi.StringOutput {
+	return o.ApplyT(func(v *MetastoreAssignment) pulumi.StringOutput { return v.WorkspaceId }).(pulumi.StringOutput)
 }
 
 type MetastoreAssignmentArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/databricks/mwsNetworks.go
+++ b/sdk/go/databricks/mwsNetworks.go
@@ -110,7 +110,7 @@ type MwsNetworks struct {
 	// (String) VPC attachment status
 	VpcStatus pulumi.StringOutput `pulumi:"vpcStatus"`
 	// (Integer) id of associated workspace
-	WorkspaceId pulumi.IntOutput `pulumi:"workspaceId"`
+	WorkspaceId pulumi.StringOutput `pulumi:"workspaceId"`
 }
 
 // NewMwsNetworks registers a new resource with the given unique name, arguments, and options.
@@ -177,7 +177,7 @@ type mwsNetworksState struct {
 	// (String) VPC attachment status
 	VpcStatus *string `pulumi:"vpcStatus"`
 	// (Integer) id of associated workspace
-	WorkspaceId *int `pulumi:"workspaceId"`
+	WorkspaceId *string `pulumi:"workspaceId"`
 }
 
 type MwsNetworksState struct {
@@ -202,7 +202,7 @@ type MwsNetworksState struct {
 	// (String) VPC attachment status
 	VpcStatus pulumi.StringPtrInput
 	// (Integer) id of associated workspace
-	WorkspaceId pulumi.IntPtrInput
+	WorkspaceId pulumi.StringPtrInput
 }
 
 func (MwsNetworksState) ElementType() reflect.Type {
@@ -231,7 +231,7 @@ type mwsNetworksArgs struct {
 	// (String) VPC attachment status
 	VpcStatus *string `pulumi:"vpcStatus"`
 	// (Integer) id of associated workspace
-	WorkspaceId *int `pulumi:"workspaceId"`
+	WorkspaceId *string `pulumi:"workspaceId"`
 }
 
 // The set of arguments for constructing a MwsNetworks resource.
@@ -257,7 +257,7 @@ type MwsNetworksArgs struct {
 	// (String) VPC attachment status
 	VpcStatus pulumi.StringPtrInput
 	// (Integer) id of associated workspace
-	WorkspaceId pulumi.IntPtrInput
+	WorkspaceId pulumi.StringPtrInput
 }
 
 func (MwsNetworksArgs) ElementType() reflect.Type {
@@ -401,8 +401,8 @@ func (o MwsNetworksOutput) VpcStatus() pulumi.StringOutput {
 }
 
 // (Integer) id of associated workspace
-func (o MwsNetworksOutput) WorkspaceId() pulumi.IntOutput {
-	return o.ApplyT(func(v *MwsNetworks) pulumi.IntOutput { return v.WorkspaceId }).(pulumi.IntOutput)
+func (o MwsNetworksOutput) WorkspaceId() pulumi.StringOutput {
+	return o.ApplyT(func(v *MwsNetworks) pulumi.StringOutput { return v.WorkspaceId }).(pulumi.StringOutput)
 }
 
 type MwsNetworksArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/databricks/mwsPermissionAssignment.go
+++ b/sdk/go/databricks/mwsPermissionAssignment.go
@@ -152,7 +152,7 @@ type MwsPermissionAssignment struct {
 	// Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
 	PrincipalId pulumi.IntOutput `pulumi:"principalId"`
 	// Databricks workspace ID.
-	WorkspaceId pulumi.IntOutput `pulumi:"workspaceId"`
+	WorkspaceId pulumi.StringOutput `pulumi:"workspaceId"`
 }
 
 // NewMwsPermissionAssignment registers a new resource with the given unique name, arguments, and options.
@@ -201,7 +201,7 @@ type mwsPermissionAssignmentState struct {
 	// Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
 	PrincipalId *int `pulumi:"principalId"`
 	// Databricks workspace ID.
-	WorkspaceId *int `pulumi:"workspaceId"`
+	WorkspaceId *string `pulumi:"workspaceId"`
 }
 
 type MwsPermissionAssignmentState struct {
@@ -212,7 +212,7 @@ type MwsPermissionAssignmentState struct {
 	// Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
 	PrincipalId pulumi.IntPtrInput
 	// Databricks workspace ID.
-	WorkspaceId pulumi.IntPtrInput
+	WorkspaceId pulumi.StringPtrInput
 }
 
 func (MwsPermissionAssignmentState) ElementType() reflect.Type {
@@ -227,7 +227,7 @@ type mwsPermissionAssignmentArgs struct {
 	// Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
 	PrincipalId int `pulumi:"principalId"`
 	// Databricks workspace ID.
-	WorkspaceId int `pulumi:"workspaceId"`
+	WorkspaceId string `pulumi:"workspaceId"`
 }
 
 // The set of arguments for constructing a MwsPermissionAssignment resource.
@@ -239,7 +239,7 @@ type MwsPermissionAssignmentArgs struct {
 	// Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
 	PrincipalId pulumi.IntInput
 	// Databricks workspace ID.
-	WorkspaceId pulumi.IntInput
+	WorkspaceId pulumi.StringInput
 }
 
 func (MwsPermissionAssignmentArgs) ElementType() reflect.Type {
@@ -342,8 +342,8 @@ func (o MwsPermissionAssignmentOutput) PrincipalId() pulumi.IntOutput {
 }
 
 // Databricks workspace ID.
-func (o MwsPermissionAssignmentOutput) WorkspaceId() pulumi.IntOutput {
-	return o.ApplyT(func(v *MwsPermissionAssignment) pulumi.IntOutput { return v.WorkspaceId }).(pulumi.IntOutput)
+func (o MwsPermissionAssignmentOutput) WorkspaceId() pulumi.StringOutput {
+	return o.ApplyT(func(v *MwsPermissionAssignment) pulumi.StringOutput { return v.WorkspaceId }).(pulumi.StringOutput)
 }
 
 type MwsPermissionAssignmentArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/databricks/mwsWorkspaces.go
+++ b/sdk/go/databricks/mwsWorkspaces.go
@@ -368,7 +368,7 @@ type MwsWorkspaces struct {
 	StorageCustomerManagedKeyId pulumi.StringPtrOutput      `pulumi:"storageCustomerManagedKeyId"`
 	Token                       MwsWorkspacesTokenPtrOutput `pulumi:"token"`
 	// (String) workspace id
-	WorkspaceId pulumi.IntOutput `pulumi:"workspaceId"`
+	WorkspaceId pulumi.StringOutput `pulumi:"workspaceId"`
 	// name of the workspace, will appear on UI.
 	WorkspaceName pulumi.StringOutput `pulumi:"workspaceName"`
 	// (String) workspace status
@@ -459,7 +459,7 @@ type mwsWorkspacesState struct {
 	StorageCustomerManagedKeyId *string             `pulumi:"storageCustomerManagedKeyId"`
 	Token                       *MwsWorkspacesToken `pulumi:"token"`
 	// (String) workspace id
-	WorkspaceId *int `pulumi:"workspaceId"`
+	WorkspaceId *string `pulumi:"workspaceId"`
 	// name of the workspace, will appear on UI.
 	WorkspaceName *string `pulumi:"workspaceName"`
 	// (String) workspace status
@@ -508,7 +508,7 @@ type MwsWorkspacesState struct {
 	StorageCustomerManagedKeyId pulumi.StringPtrInput
 	Token                       MwsWorkspacesTokenPtrInput
 	// (String) workspace id
-	WorkspaceId pulumi.IntPtrInput
+	WorkspaceId pulumi.StringPtrInput
 	// name of the workspace, will appear on UI.
 	WorkspaceName pulumi.StringPtrInput
 	// (String) workspace status
@@ -561,7 +561,7 @@ type mwsWorkspacesArgs struct {
 	StorageCustomerManagedKeyId *string             `pulumi:"storageCustomerManagedKeyId"`
 	Token                       *MwsWorkspacesToken `pulumi:"token"`
 	// (String) workspace id
-	WorkspaceId *int `pulumi:"workspaceId"`
+	WorkspaceId *string `pulumi:"workspaceId"`
 	// name of the workspace, will appear on UI.
 	WorkspaceName string `pulumi:"workspaceName"`
 	// (String) workspace status
@@ -611,7 +611,7 @@ type MwsWorkspacesArgs struct {
 	StorageCustomerManagedKeyId pulumi.StringPtrInput
 	Token                       MwsWorkspacesTokenPtrInput
 	// (String) workspace id
-	WorkspaceId pulumi.IntPtrInput
+	WorkspaceId pulumi.StringPtrInput
 	// name of the workspace, will appear on UI.
 	WorkspaceName pulumi.StringInput
 	// (String) workspace status
@@ -809,8 +809,8 @@ func (o MwsWorkspacesOutput) Token() MwsWorkspacesTokenPtrOutput {
 }
 
 // (String) workspace id
-func (o MwsWorkspacesOutput) WorkspaceId() pulumi.IntOutput {
-	return o.ApplyT(func(v *MwsWorkspaces) pulumi.IntOutput { return v.WorkspaceId }).(pulumi.IntOutput)
+func (o MwsWorkspacesOutput) WorkspaceId() pulumi.StringOutput {
+	return o.ApplyT(func(v *MwsWorkspaces) pulumi.StringOutput { return v.WorkspaceId }).(pulumi.StringOutput)
 }
 
 // name of the workspace, will appear on UI.

--- a/sdk/java/src/main/java/com/pulumi/databricks/CatalogWorkspaceBinding.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/CatalogWorkspaceBinding.java
@@ -10,7 +10,6 @@ import com.pulumi.core.internal.Codegen;
 import com.pulumi.databricks.CatalogWorkspaceBindingArgs;
 import com.pulumi.databricks.Utilities;
 import com.pulumi.databricks.inputs.CatalogWorkspaceBindingState;
-import java.lang.Integer;
 import java.lang.String;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -126,14 +125,14 @@ public class CatalogWorkspaceBinding extends com.pulumi.resources.CustomResource
      * ID of the workspace. Change forces creation of a new resource.
      * 
      */
-    @Export(name="workspaceId", refs={Integer.class}, tree="[0]")
-    private Output</* @Nullable */ Integer> workspaceId;
+    @Export(name="workspaceId", refs={String.class}, tree="[0]")
+    private Output</* @Nullable */ String> workspaceId;
 
     /**
      * @return ID of the workspace. Change forces creation of a new resource.
      * 
      */
-    public Output<Optional<Integer>> workspaceId() {
+    public Output<Optional<String>> workspaceId() {
         return Codegen.optional(this.workspaceId);
     }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/CatalogWorkspaceBindingArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/CatalogWorkspaceBindingArgs.java
@@ -5,7 +5,6 @@ package com.pulumi.databricks;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
-import java.lang.Integer;
 import java.lang.String;
 import java.util.Objects;
 import java.util.Optional;
@@ -85,13 +84,13 @@ public final class CatalogWorkspaceBindingArgs extends com.pulumi.resources.Reso
      * 
      */
     @Import(name="workspaceId")
-    private @Nullable Output<Integer> workspaceId;
+    private @Nullable Output<String> workspaceId;
 
     /**
      * @return ID of the workspace. Change forces creation of a new resource.
      * 
      */
-    public Optional<Output<Integer>> workspaceId() {
+    public Optional<Output<String>> workspaceId() {
         return Optional.ofNullable(this.workspaceId);
     }
 
@@ -217,7 +216,7 @@ public final class CatalogWorkspaceBindingArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder workspaceId(@Nullable Output<Integer> workspaceId) {
+        public Builder workspaceId(@Nullable Output<String> workspaceId) {
             $.workspaceId = workspaceId;
             return this;
         }
@@ -228,7 +227,7 @@ public final class CatalogWorkspaceBindingArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder workspaceId(Integer workspaceId) {
+        public Builder workspaceId(String workspaceId) {
             return workspaceId(Output.of(workspaceId));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/MetastoreAssignment.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/MetastoreAssignment.java
@@ -10,7 +10,6 @@ import com.pulumi.core.internal.Codegen;
 import com.pulumi.databricks.MetastoreAssignmentArgs;
 import com.pulumi.databricks.Utilities;
 import com.pulumi.databricks.inputs.MetastoreAssignmentState;
-import java.lang.Integer;
 import java.lang.String;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -109,14 +108,14 @@ public class MetastoreAssignment extends com.pulumi.resources.CustomResource {
      * id of the workspace for the assignment
      * 
      */
-    @Export(name="workspaceId", refs={Integer.class}, tree="[0]")
-    private Output<Integer> workspaceId;
+    @Export(name="workspaceId", refs={String.class}, tree="[0]")
+    private Output<String> workspaceId;
 
     /**
      * @return id of the workspace for the assignment
      * 
      */
-    public Output<Integer> workspaceId() {
+    public Output<String> workspaceId() {
         return this.workspaceId;
     }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/MetastoreAssignmentArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/MetastoreAssignmentArgs.java
@@ -6,7 +6,6 @@ package com.pulumi.databricks;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
-import java.lang.Integer;
 import java.lang.String;
 import java.util.Objects;
 import java.util.Optional;
@@ -52,13 +51,13 @@ public final class MetastoreAssignmentArgs extends com.pulumi.resources.Resource
      * 
      */
     @Import(name="workspaceId", required=true)
-    private Output<Integer> workspaceId;
+    private Output<String> workspaceId;
 
     /**
      * @return id of the workspace for the assignment
      * 
      */
-    public Output<Integer> workspaceId() {
+    public Output<String> workspaceId() {
         return this.workspaceId;
     }
 
@@ -136,7 +135,7 @@ public final class MetastoreAssignmentArgs extends com.pulumi.resources.Resource
          * @return builder
          * 
          */
-        public Builder workspaceId(Output<Integer> workspaceId) {
+        public Builder workspaceId(Output<String> workspaceId) {
             $.workspaceId = workspaceId;
             return this;
         }
@@ -147,7 +146,7 @@ public final class MetastoreAssignmentArgs extends com.pulumi.resources.Resource
          * @return builder
          * 
          */
-        public Builder workspaceId(Integer workspaceId) {
+        public Builder workspaceId(String workspaceId) {
             return workspaceId(Output.of(workspaceId));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/MwsNetworks.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/MwsNetworks.java
@@ -239,14 +239,14 @@ public class MwsNetworks extends com.pulumi.resources.CustomResource {
      * (Integer) id of associated workspace
      * 
      */
-    @Export(name="workspaceId", refs={Integer.class}, tree="[0]")
-    private Output<Integer> workspaceId;
+    @Export(name="workspaceId", refs={String.class}, tree="[0]")
+    private Output<String> workspaceId;
 
     /**
      * @return (Integer) id of associated workspace
      * 
      */
-    public Output<Integer> workspaceId() {
+    public Output<String> workspaceId() {
         return this.workspaceId;
     }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/MwsNetworksArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/MwsNetworksArgs.java
@@ -175,13 +175,13 @@ public final class MwsNetworksArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="workspaceId")
-    private @Nullable Output<Integer> workspaceId;
+    private @Nullable Output<String> workspaceId;
 
     /**
      * @return (Integer) id of associated workspace
      * 
      */
-    public Optional<Output<Integer>> workspaceId() {
+    public Optional<Output<String>> workspaceId() {
         return Optional.ofNullable(this.workspaceId);
     }
 
@@ -457,7 +457,7 @@ public final class MwsNetworksArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder workspaceId(@Nullable Output<Integer> workspaceId) {
+        public Builder workspaceId(@Nullable Output<String> workspaceId) {
             $.workspaceId = workspaceId;
             return this;
         }
@@ -468,7 +468,7 @@ public final class MwsNetworksArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder workspaceId(Integer workspaceId) {
+        public Builder workspaceId(String workspaceId) {
             return workspaceId(Output.of(workspaceId));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/MwsPermissionAssignment.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/MwsPermissionAssignment.java
@@ -201,14 +201,14 @@ public class MwsPermissionAssignment extends com.pulumi.resources.CustomResource
      * Databricks workspace ID.
      * 
      */
-    @Export(name="workspaceId", refs={Integer.class}, tree="[0]")
-    private Output<Integer> workspaceId;
+    @Export(name="workspaceId", refs={String.class}, tree="[0]")
+    private Output<String> workspaceId;
 
     /**
      * @return Databricks workspace ID.
      * 
      */
-    public Output<Integer> workspaceId() {
+    public Output<String> workspaceId() {
         return this.workspaceId;
     }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/MwsPermissionAssignmentArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/MwsPermissionAssignmentArgs.java
@@ -55,13 +55,13 @@ public final class MwsPermissionAssignmentArgs extends com.pulumi.resources.Reso
      * 
      */
     @Import(name="workspaceId", required=true)
-    private Output<Integer> workspaceId;
+    private Output<String> workspaceId;
 
     /**
      * @return Databricks workspace ID.
      * 
      */
-    public Output<Integer> workspaceId() {
+    public Output<String> workspaceId() {
         return this.workspaceId;
     }
 
@@ -155,7 +155,7 @@ public final class MwsPermissionAssignmentArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder workspaceId(Output<Integer> workspaceId) {
+        public Builder workspaceId(Output<String> workspaceId) {
             $.workspaceId = workspaceId;
             return this;
         }
@@ -166,7 +166,7 @@ public final class MwsPermissionAssignmentArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder workspaceId(Integer workspaceId) {
+        public Builder workspaceId(String workspaceId) {
             return workspaceId(Output.of(workspaceId));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/MwsWorkspaces.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/MwsWorkspaces.java
@@ -598,14 +598,14 @@ public class MwsWorkspaces extends com.pulumi.resources.CustomResource {
      * (String) workspace id
      * 
      */
-    @Export(name="workspaceId", refs={Integer.class}, tree="[0]")
-    private Output<Integer> workspaceId;
+    @Export(name="workspaceId", refs={String.class}, tree="[0]")
+    private Output<String> workspaceId;
 
     /**
      * @return (String) workspace id
      * 
      */
-    public Output<Integer> workspaceId() {
+    public Output<String> workspaceId() {
         return this.workspaceId;
     }
     /**

--- a/sdk/java/src/main/java/com/pulumi/databricks/MwsWorkspacesArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/MwsWorkspacesArgs.java
@@ -301,13 +301,13 @@ public final class MwsWorkspacesArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="workspaceId")
-    private @Nullable Output<Integer> workspaceId;
+    private @Nullable Output<String> workspaceId;
 
     /**
      * @return (String) workspace id
      * 
      */
-    public Optional<Output<Integer>> workspaceId() {
+    public Optional<Output<String>> workspaceId() {
         return Optional.ofNullable(this.workspaceId);
     }
 
@@ -799,7 +799,7 @@ public final class MwsWorkspacesArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder workspaceId(@Nullable Output<Integer> workspaceId) {
+        public Builder workspaceId(@Nullable Output<String> workspaceId) {
             $.workspaceId = workspaceId;
             return this;
         }
@@ -810,7 +810,7 @@ public final class MwsWorkspacesArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder workspaceId(Integer workspaceId) {
+        public Builder workspaceId(String workspaceId) {
             return workspaceId(Output.of(workspaceId));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/inputs/CatalogWorkspaceBindingState.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/inputs/CatalogWorkspaceBindingState.java
@@ -5,7 +5,6 @@ package com.pulumi.databricks.inputs;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
-import java.lang.Integer;
 import java.lang.String;
 import java.util.Objects;
 import java.util.Optional;
@@ -85,13 +84,13 @@ public final class CatalogWorkspaceBindingState extends com.pulumi.resources.Res
      * 
      */
     @Import(name="workspaceId")
-    private @Nullable Output<Integer> workspaceId;
+    private @Nullable Output<String> workspaceId;
 
     /**
      * @return ID of the workspace. Change forces creation of a new resource.
      * 
      */
-    public Optional<Output<Integer>> workspaceId() {
+    public Optional<Output<String>> workspaceId() {
         return Optional.ofNullable(this.workspaceId);
     }
 
@@ -217,7 +216,7 @@ public final class CatalogWorkspaceBindingState extends com.pulumi.resources.Res
          * @return builder
          * 
          */
-        public Builder workspaceId(@Nullable Output<Integer> workspaceId) {
+        public Builder workspaceId(@Nullable Output<String> workspaceId) {
             $.workspaceId = workspaceId;
             return this;
         }
@@ -228,7 +227,7 @@ public final class CatalogWorkspaceBindingState extends com.pulumi.resources.Res
          * @return builder
          * 
          */
-        public Builder workspaceId(Integer workspaceId) {
+        public Builder workspaceId(String workspaceId) {
             return workspaceId(Output.of(workspaceId));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/inputs/MetastoreAssignmentState.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/inputs/MetastoreAssignmentState.java
@@ -5,7 +5,6 @@ package com.pulumi.databricks.inputs;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
-import java.lang.Integer;
 import java.lang.String;
 import java.util.Objects;
 import java.util.Optional;
@@ -51,13 +50,13 @@ public final class MetastoreAssignmentState extends com.pulumi.resources.Resourc
      * 
      */
     @Import(name="workspaceId")
-    private @Nullable Output<Integer> workspaceId;
+    private @Nullable Output<String> workspaceId;
 
     /**
      * @return id of the workspace for the assignment
      * 
      */
-    public Optional<Output<Integer>> workspaceId() {
+    public Optional<Output<String>> workspaceId() {
         return Optional.ofNullable(this.workspaceId);
     }
 
@@ -135,7 +134,7 @@ public final class MetastoreAssignmentState extends com.pulumi.resources.Resourc
          * @return builder
          * 
          */
-        public Builder workspaceId(@Nullable Output<Integer> workspaceId) {
+        public Builder workspaceId(@Nullable Output<String> workspaceId) {
             $.workspaceId = workspaceId;
             return this;
         }
@@ -146,7 +145,7 @@ public final class MetastoreAssignmentState extends com.pulumi.resources.Resourc
          * @return builder
          * 
          */
-        public Builder workspaceId(Integer workspaceId) {
+        public Builder workspaceId(String workspaceId) {
             return workspaceId(Output.of(workspaceId));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/inputs/MwsNetworksState.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/inputs/MwsNetworksState.java
@@ -174,13 +174,13 @@ public final class MwsNetworksState extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="workspaceId")
-    private @Nullable Output<Integer> workspaceId;
+    private @Nullable Output<String> workspaceId;
 
     /**
      * @return (Integer) id of associated workspace
      * 
      */
-    public Optional<Output<Integer>> workspaceId() {
+    public Optional<Output<String>> workspaceId() {
         return Optional.ofNullable(this.workspaceId);
     }
 
@@ -456,7 +456,7 @@ public final class MwsNetworksState extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder workspaceId(@Nullable Output<Integer> workspaceId) {
+        public Builder workspaceId(@Nullable Output<String> workspaceId) {
             $.workspaceId = workspaceId;
             return this;
         }
@@ -467,7 +467,7 @@ public final class MwsNetworksState extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder workspaceId(Integer workspaceId) {
+        public Builder workspaceId(String workspaceId) {
             return workspaceId(Output.of(workspaceId));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/inputs/MwsPermissionAssignmentState.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/inputs/MwsPermissionAssignmentState.java
@@ -56,13 +56,13 @@ public final class MwsPermissionAssignmentState extends com.pulumi.resources.Res
      * 
      */
     @Import(name="workspaceId")
-    private @Nullable Output<Integer> workspaceId;
+    private @Nullable Output<String> workspaceId;
 
     /**
      * @return Databricks workspace ID.
      * 
      */
-    public Optional<Output<Integer>> workspaceId() {
+    public Optional<Output<String>> workspaceId() {
         return Optional.ofNullable(this.workspaceId);
     }
 
@@ -156,7 +156,7 @@ public final class MwsPermissionAssignmentState extends com.pulumi.resources.Res
          * @return builder
          * 
          */
-        public Builder workspaceId(@Nullable Output<Integer> workspaceId) {
+        public Builder workspaceId(@Nullable Output<String> workspaceId) {
             $.workspaceId = workspaceId;
             return this;
         }
@@ -167,7 +167,7 @@ public final class MwsPermissionAssignmentState extends com.pulumi.resources.Res
          * @return builder
          * 
          */
-        public Builder workspaceId(Integer workspaceId) {
+        public Builder workspaceId(String workspaceId) {
             return workspaceId(Output.of(workspaceId));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/inputs/MwsWorkspacesState.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/inputs/MwsWorkspacesState.java
@@ -300,13 +300,13 @@ public final class MwsWorkspacesState extends com.pulumi.resources.ResourceArgs 
      * 
      */
     @Import(name="workspaceId")
-    private @Nullable Output<Integer> workspaceId;
+    private @Nullable Output<String> workspaceId;
 
     /**
      * @return (String) workspace id
      * 
      */
-    public Optional<Output<Integer>> workspaceId() {
+    public Optional<Output<String>> workspaceId() {
         return Optional.ofNullable(this.workspaceId);
     }
 
@@ -798,7 +798,7 @@ public final class MwsWorkspacesState extends com.pulumi.resources.ResourceArgs 
          * @return builder
          * 
          */
-        public Builder workspaceId(@Nullable Output<Integer> workspaceId) {
+        public Builder workspaceId(@Nullable Output<String> workspaceId) {
             $.workspaceId = workspaceId;
             return this;
         }
@@ -809,7 +809,7 @@ public final class MwsWorkspacesState extends com.pulumi.resources.ResourceArgs 
          * @return builder
          * 
          */
-        public Builder workspaceId(Integer workspaceId) {
+        public Builder workspaceId(String workspaceId) {
             return workspaceId(Output.of(workspaceId));
         }
 

--- a/sdk/nodejs/catalogWorkspaceBinding.ts
+++ b/sdk/nodejs/catalogWorkspaceBinding.ts
@@ -76,7 +76,7 @@ export class CatalogWorkspaceBinding extends pulumi.CustomResource {
     /**
      * ID of the workspace. Change forces creation of a new resource.
      */
-    public readonly workspaceId!: pulumi.Output<number | undefined>;
+    public readonly workspaceId!: pulumi.Output<string | undefined>;
 
     /**
      * Create a CatalogWorkspaceBinding resource with the given unique name, arguments, and options.
@@ -132,7 +132,7 @@ export interface CatalogWorkspaceBindingState {
     /**
      * ID of the workspace. Change forces creation of a new resource.
      */
-    workspaceId?: pulumi.Input<number>;
+    workspaceId?: pulumi.Input<string>;
 }
 
 /**
@@ -158,5 +158,5 @@ export interface CatalogWorkspaceBindingArgs {
     /**
      * ID of the workspace. Change forces creation of a new resource.
      */
-    workspaceId?: pulumi.Input<number>;
+    workspaceId?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/metastoreAssignment.ts
+++ b/sdk/nodejs/metastoreAssignment.ts
@@ -77,7 +77,7 @@ export class MetastoreAssignment extends pulumi.CustomResource {
     /**
      * id of the workspace for the assignment
      */
-    public readonly workspaceId!: pulumi.Output<number>;
+    public readonly workspaceId!: pulumi.Output<string>;
 
     /**
      * Create a MetastoreAssignment resource with the given unique name, arguments, and options.
@@ -127,7 +127,7 @@ export interface MetastoreAssignmentState {
     /**
      * id of the workspace for the assignment
      */
-    workspaceId?: pulumi.Input<number>;
+    workspaceId?: pulumi.Input<string>;
 }
 
 /**
@@ -145,5 +145,5 @@ export interface MetastoreAssignmentArgs {
     /**
      * id of the workspace for the assignment
      */
-    workspaceId: pulumi.Input<number>;
+    workspaceId: pulumi.Input<string>;
 }

--- a/sdk/nodejs/mwsNetworks.ts
+++ b/sdk/nodejs/mwsNetworks.ts
@@ -150,7 +150,7 @@ export class MwsNetworks extends pulumi.CustomResource {
     /**
      * (Integer) id of associated workspace
      */
-    public readonly workspaceId!: pulumi.Output<number>;
+    public readonly workspaceId!: pulumi.Output<string>;
 
     /**
      * Create a MwsNetworks resource with the given unique name, arguments, and options.
@@ -250,7 +250,7 @@ export interface MwsNetworksState {
     /**
      * (Integer) id of associated workspace
      */
-    workspaceId?: pulumi.Input<number>;
+    workspaceId?: pulumi.Input<string>;
 }
 
 /**
@@ -298,5 +298,5 @@ export interface MwsNetworksArgs {
     /**
      * (Integer) id of associated workspace
      */
-    workspaceId?: pulumi.Input<number>;
+    workspaceId?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/mwsPermissionAssignment.ts
+++ b/sdk/nodejs/mwsPermissionAssignment.ts
@@ -111,7 +111,7 @@ export class MwsPermissionAssignment extends pulumi.CustomResource {
     /**
      * Databricks workspace ID.
      */
-    public readonly workspaceId!: pulumi.Output<number>;
+    public readonly workspaceId!: pulumi.Output<string>;
 
     /**
      * Create a MwsPermissionAssignment resource with the given unique name, arguments, and options.
@@ -166,7 +166,7 @@ export interface MwsPermissionAssignmentState {
     /**
      * Databricks workspace ID.
      */
-    workspaceId?: pulumi.Input<number>;
+    workspaceId?: pulumi.Input<string>;
 }
 
 /**
@@ -186,5 +186,5 @@ export interface MwsPermissionAssignmentArgs {
     /**
      * Databricks workspace ID.
      */
-    workspaceId: pulumi.Input<number>;
+    workspaceId: pulumi.Input<string>;
 }

--- a/sdk/nodejs/mwsWorkspaces.ts
+++ b/sdk/nodejs/mwsWorkspaces.ts
@@ -306,7 +306,7 @@ export class MwsWorkspaces extends pulumi.CustomResource {
     /**
      * (String) workspace id
      */
-    public readonly workspaceId!: pulumi.Output<number>;
+    public readonly workspaceId!: pulumi.Output<string>;
     /**
      * name of the workspace, will appear on UI.
      */
@@ -478,7 +478,7 @@ export interface MwsWorkspacesState {
     /**
      * (String) workspace id
      */
-    workspaceId?: pulumi.Input<number>;
+    workspaceId?: pulumi.Input<string>;
     /**
      * name of the workspace, will appear on UI.
      */
@@ -570,7 +570,7 @@ export interface MwsWorkspacesArgs {
     /**
      * (String) workspace id
      */
-    workspaceId?: pulumi.Input<number>;
+    workspaceId?: pulumi.Input<string>;
     /**
      * name of the workspace, will appear on UI.
      */

--- a/sdk/python/pulumi_databricks/catalog_workspace_binding.py
+++ b/sdk/python/pulumi_databricks/catalog_workspace_binding.py
@@ -18,13 +18,13 @@ class CatalogWorkspaceBindingArgs:
                  catalog_name: Optional[pulumi.Input[str]] = None,
                  securable_name: Optional[pulumi.Input[str]] = None,
                  securable_type: Optional[pulumi.Input[str]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None):
+                 workspace_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a CatalogWorkspaceBinding resource.
         :param pulumi.Input[str] binding_type: Binding mode. Default to `BINDING_TYPE_READ_WRITE`. Possible values are `BINDING_TYPE_READ_ONLY`, `BINDING_TYPE_READ_WRITE`
         :param pulumi.Input[str] securable_name: Name of securable. Change forces creation of a new resource.
         :param pulumi.Input[str] securable_type: Type of securable. Default to `catalog`. Change forces creation of a new resource.
-        :param pulumi.Input[int] workspace_id: ID of the workspace. Change forces creation of a new resource.
+        :param pulumi.Input[str] workspace_id: ID of the workspace. Change forces creation of a new resource.
         """
         if binding_type is not None:
             pulumi.set(__self__, "binding_type", binding_type)
@@ -90,14 +90,14 @@ class CatalogWorkspaceBindingArgs:
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> Optional[pulumi.Input[int]]:
+    def workspace_id(self) -> Optional[pulumi.Input[str]]:
         """
         ID of the workspace. Change forces creation of a new resource.
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: Optional[pulumi.Input[int]]):
+    def workspace_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "workspace_id", value)
 
 
@@ -108,13 +108,13 @@ class _CatalogWorkspaceBindingState:
                  catalog_name: Optional[pulumi.Input[str]] = None,
                  securable_name: Optional[pulumi.Input[str]] = None,
                  securable_type: Optional[pulumi.Input[str]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None):
+                 workspace_id: Optional[pulumi.Input[str]] = None):
         """
         Input properties used for looking up and filtering CatalogWorkspaceBinding resources.
         :param pulumi.Input[str] binding_type: Binding mode. Default to `BINDING_TYPE_READ_WRITE`. Possible values are `BINDING_TYPE_READ_ONLY`, `BINDING_TYPE_READ_WRITE`
         :param pulumi.Input[str] securable_name: Name of securable. Change forces creation of a new resource.
         :param pulumi.Input[str] securable_type: Type of securable. Default to `catalog`. Change forces creation of a new resource.
-        :param pulumi.Input[int] workspace_id: ID of the workspace. Change forces creation of a new resource.
+        :param pulumi.Input[str] workspace_id: ID of the workspace. Change forces creation of a new resource.
         """
         if binding_type is not None:
             pulumi.set(__self__, "binding_type", binding_type)
@@ -180,14 +180,14 @@ class _CatalogWorkspaceBindingState:
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> Optional[pulumi.Input[int]]:
+    def workspace_id(self) -> Optional[pulumi.Input[str]]:
         """
         ID of the workspace. Change forces creation of a new resource.
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: Optional[pulumi.Input[int]]):
+    def workspace_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "workspace_id", value)
 
 
@@ -200,7 +200,7 @@ class CatalogWorkspaceBinding(pulumi.CustomResource):
                  catalog_name: Optional[pulumi.Input[str]] = None,
                  securable_name: Optional[pulumi.Input[str]] = None,
                  securable_type: Optional[pulumi.Input[str]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None,
+                 workspace_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
         ## Example Usage
@@ -230,7 +230,7 @@ class CatalogWorkspaceBinding(pulumi.CustomResource):
         :param pulumi.Input[str] binding_type: Binding mode. Default to `BINDING_TYPE_READ_WRITE`. Possible values are `BINDING_TYPE_READ_ONLY`, `BINDING_TYPE_READ_WRITE`
         :param pulumi.Input[str] securable_name: Name of securable. Change forces creation of a new resource.
         :param pulumi.Input[str] securable_type: Type of securable. Default to `catalog`. Change forces creation of a new resource.
-        :param pulumi.Input[int] workspace_id: ID of the workspace. Change forces creation of a new resource.
+        :param pulumi.Input[str] workspace_id: ID of the workspace. Change forces creation of a new resource.
         """
         ...
     @overload
@@ -280,7 +280,7 @@ class CatalogWorkspaceBinding(pulumi.CustomResource):
                  catalog_name: Optional[pulumi.Input[str]] = None,
                  securable_name: Optional[pulumi.Input[str]] = None,
                  securable_type: Optional[pulumi.Input[str]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None,
+                 workspace_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -309,7 +309,7 @@ class CatalogWorkspaceBinding(pulumi.CustomResource):
             catalog_name: Optional[pulumi.Input[str]] = None,
             securable_name: Optional[pulumi.Input[str]] = None,
             securable_type: Optional[pulumi.Input[str]] = None,
-            workspace_id: Optional[pulumi.Input[int]] = None) -> 'CatalogWorkspaceBinding':
+            workspace_id: Optional[pulumi.Input[str]] = None) -> 'CatalogWorkspaceBinding':
         """
         Get an existing CatalogWorkspaceBinding resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.
@@ -320,7 +320,7 @@ class CatalogWorkspaceBinding(pulumi.CustomResource):
         :param pulumi.Input[str] binding_type: Binding mode. Default to `BINDING_TYPE_READ_WRITE`. Possible values are `BINDING_TYPE_READ_ONLY`, `BINDING_TYPE_READ_WRITE`
         :param pulumi.Input[str] securable_name: Name of securable. Change forces creation of a new resource.
         :param pulumi.Input[str] securable_type: Type of securable. Default to `catalog`. Change forces creation of a new resource.
-        :param pulumi.Input[int] workspace_id: ID of the workspace. Change forces creation of a new resource.
+        :param pulumi.Input[str] workspace_id: ID of the workspace. Change forces creation of a new resource.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
@@ -367,7 +367,7 @@ class CatalogWorkspaceBinding(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> pulumi.Output[Optional[int]]:
+    def workspace_id(self) -> pulumi.Output[Optional[str]]:
         """
         ID of the workspace. Change forces creation of a new resource.
         """

--- a/sdk/python/pulumi_databricks/metastore_assignment.py
+++ b/sdk/python/pulumi_databricks/metastore_assignment.py
@@ -15,12 +15,12 @@ __all__ = ['MetastoreAssignmentArgs', 'MetastoreAssignment']
 class MetastoreAssignmentArgs:
     def __init__(__self__, *,
                  metastore_id: pulumi.Input[str],
-                 workspace_id: pulumi.Input[int],
+                 workspace_id: pulumi.Input[str],
                  default_catalog_name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a MetastoreAssignment resource.
         :param pulumi.Input[str] metastore_id: Unique identifier of the parent Metastore
-        :param pulumi.Input[int] workspace_id: id of the workspace for the assignment
+        :param pulumi.Input[str] workspace_id: id of the workspace for the assignment
         :param pulumi.Input[str] default_catalog_name: Default catalog used for this assignment, default to `hive_metastore`
         """
         pulumi.set(__self__, "metastore_id", metastore_id)
@@ -42,14 +42,14 @@ class MetastoreAssignmentArgs:
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> pulumi.Input[int]:
+    def workspace_id(self) -> pulumi.Input[str]:
         """
         id of the workspace for the assignment
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: pulumi.Input[int]):
+    def workspace_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "workspace_id", value)
 
     @property
@@ -70,12 +70,12 @@ class _MetastoreAssignmentState:
     def __init__(__self__, *,
                  default_catalog_name: Optional[pulumi.Input[str]] = None,
                  metastore_id: Optional[pulumi.Input[str]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None):
+                 workspace_id: Optional[pulumi.Input[str]] = None):
         """
         Input properties used for looking up and filtering MetastoreAssignment resources.
         :param pulumi.Input[str] default_catalog_name: Default catalog used for this assignment, default to `hive_metastore`
         :param pulumi.Input[str] metastore_id: Unique identifier of the parent Metastore
-        :param pulumi.Input[int] workspace_id: id of the workspace for the assignment
+        :param pulumi.Input[str] workspace_id: id of the workspace for the assignment
         """
         if default_catalog_name is not None:
             pulumi.set(__self__, "default_catalog_name", default_catalog_name)
@@ -110,14 +110,14 @@ class _MetastoreAssignmentState:
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> Optional[pulumi.Input[int]]:
+    def workspace_id(self) -> Optional[pulumi.Input[str]]:
         """
         id of the workspace for the assignment
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: Optional[pulumi.Input[int]]):
+    def workspace_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "workspace_id", value)
 
 
@@ -128,7 +128,7 @@ class MetastoreAssignment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  default_catalog_name: Optional[pulumi.Input[str]] = None,
                  metastore_id: Optional[pulumi.Input[str]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None,
+                 workspace_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
         > **Note** This resource could be only used with account-level provider!
@@ -166,7 +166,7 @@ class MetastoreAssignment(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] default_catalog_name: Default catalog used for this assignment, default to `hive_metastore`
         :param pulumi.Input[str] metastore_id: Unique identifier of the parent Metastore
-        :param pulumi.Input[int] workspace_id: id of the workspace for the assignment
+        :param pulumi.Input[str] workspace_id: id of the workspace for the assignment
         """
         ...
     @overload
@@ -223,7 +223,7 @@ class MetastoreAssignment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  default_catalog_name: Optional[pulumi.Input[str]] = None,
                  metastore_id: Optional[pulumi.Input[str]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None,
+                 workspace_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -252,7 +252,7 @@ class MetastoreAssignment(pulumi.CustomResource):
             opts: Optional[pulumi.ResourceOptions] = None,
             default_catalog_name: Optional[pulumi.Input[str]] = None,
             metastore_id: Optional[pulumi.Input[str]] = None,
-            workspace_id: Optional[pulumi.Input[int]] = None) -> 'MetastoreAssignment':
+            workspace_id: Optional[pulumi.Input[str]] = None) -> 'MetastoreAssignment':
         """
         Get an existing MetastoreAssignment resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.
@@ -262,7 +262,7 @@ class MetastoreAssignment(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] default_catalog_name: Default catalog used for this assignment, default to `hive_metastore`
         :param pulumi.Input[str] metastore_id: Unique identifier of the parent Metastore
-        :param pulumi.Input[int] workspace_id: id of the workspace for the assignment
+        :param pulumi.Input[str] workspace_id: id of the workspace for the assignment
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
@@ -291,7 +291,7 @@ class MetastoreAssignment(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> pulumi.Output[int]:
+    def workspace_id(self) -> pulumi.Output[str]:
         """
         id of the workspace for the assignment
         """

--- a/sdk/python/pulumi_databricks/mws_networks.py
+++ b/sdk/python/pulumi_databricks/mws_networks.py
@@ -27,7 +27,7 @@ class MwsNetworksArgs:
                  vpc_endpoints: Optional[pulumi.Input['MwsNetworksVpcEndpointsArgs']] = None,
                  vpc_id: Optional[pulumi.Input[str]] = None,
                  vpc_status: Optional[pulumi.Input[str]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None):
+                 workspace_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a MwsNetworks resource.
         :param pulumi.Input[str] account_id: Account Id that could be found in the top right corner of [Accounts Console](https://accounts.cloud.databricks.com/)
@@ -39,7 +39,7 @@ class MwsNetworksArgs:
         :param pulumi.Input['MwsNetworksVpcEndpointsArgs'] vpc_endpoints: mapping of MwsVpcEndpoint for PrivateLink or Private Service Connect connections
         :param pulumi.Input[str] vpc_id: aws_vpc id
         :param pulumi.Input[str] vpc_status: (String) VPC attachment status
-        :param pulumi.Input[int] workspace_id: (Integer) id of associated workspace
+        :param pulumi.Input[str] workspace_id: (Integer) id of associated workspace
         """
         pulumi.set(__self__, "account_id", account_id)
         pulumi.set(__self__, "network_name", network_name)
@@ -192,14 +192,14 @@ class MwsNetworksArgs:
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> Optional[pulumi.Input[int]]:
+    def workspace_id(self) -> Optional[pulumi.Input[str]]:
         """
         (Integer) id of associated workspace
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: Optional[pulumi.Input[int]]):
+    def workspace_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "workspace_id", value)
 
 
@@ -217,7 +217,7 @@ class _MwsNetworksState:
                  vpc_endpoints: Optional[pulumi.Input['MwsNetworksVpcEndpointsArgs']] = None,
                  vpc_id: Optional[pulumi.Input[str]] = None,
                  vpc_status: Optional[pulumi.Input[str]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None):
+                 workspace_id: Optional[pulumi.Input[str]] = None):
         """
         Input properties used for looking up and filtering MwsNetworks resources.
         :param pulumi.Input[str] account_id: Account Id that could be found in the top right corner of [Accounts Console](https://accounts.cloud.databricks.com/)
@@ -229,7 +229,7 @@ class _MwsNetworksState:
         :param pulumi.Input['MwsNetworksVpcEndpointsArgs'] vpc_endpoints: mapping of MwsVpcEndpoint for PrivateLink or Private Service Connect connections
         :param pulumi.Input[str] vpc_id: aws_vpc id
         :param pulumi.Input[str] vpc_status: (String) VPC attachment status
-        :param pulumi.Input[int] workspace_id: (Integer) id of associated workspace
+        :param pulumi.Input[str] workspace_id: (Integer) id of associated workspace
         """
         if account_id is not None:
             pulumi.set(__self__, "account_id", account_id)
@@ -384,14 +384,14 @@ class _MwsNetworksState:
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> Optional[pulumi.Input[int]]:
+    def workspace_id(self) -> Optional[pulumi.Input[str]]:
         """
         (Integer) id of associated workspace
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: Optional[pulumi.Input[int]]):
+    def workspace_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "workspace_id", value)
 
 
@@ -411,7 +411,7 @@ class MwsNetworks(pulumi.CustomResource):
                  vpc_endpoints: Optional[pulumi.Input[pulumi.InputType['MwsNetworksVpcEndpointsArgs']]] = None,
                  vpc_id: Optional[pulumi.Input[str]] = None,
                  vpc_status: Optional[pulumi.Input[str]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None,
+                 workspace_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
         ## Databricks on AWS usage
@@ -499,7 +499,7 @@ class MwsNetworks(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['MwsNetworksVpcEndpointsArgs']] vpc_endpoints: mapping of MwsVpcEndpoint for PrivateLink or Private Service Connect connections
         :param pulumi.Input[str] vpc_id: aws_vpc id
         :param pulumi.Input[str] vpc_status: (String) VPC attachment status
-        :param pulumi.Input[int] workspace_id: (Integer) id of associated workspace
+        :param pulumi.Input[str] workspace_id: (Integer) id of associated workspace
         """
         ...
     @overload
@@ -608,7 +608,7 @@ class MwsNetworks(pulumi.CustomResource):
                  vpc_endpoints: Optional[pulumi.Input[pulumi.InputType['MwsNetworksVpcEndpointsArgs']]] = None,
                  vpc_id: Optional[pulumi.Input[str]] = None,
                  vpc_status: Optional[pulumi.Input[str]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None,
+                 workspace_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -657,7 +657,7 @@ class MwsNetworks(pulumi.CustomResource):
             vpc_endpoints: Optional[pulumi.Input[pulumi.InputType['MwsNetworksVpcEndpointsArgs']]] = None,
             vpc_id: Optional[pulumi.Input[str]] = None,
             vpc_status: Optional[pulumi.Input[str]] = None,
-            workspace_id: Optional[pulumi.Input[int]] = None) -> 'MwsNetworks':
+            workspace_id: Optional[pulumi.Input[str]] = None) -> 'MwsNetworks':
         """
         Get an existing MwsNetworks resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.
@@ -674,7 +674,7 @@ class MwsNetworks(pulumi.CustomResource):
         :param pulumi.Input[pulumi.InputType['MwsNetworksVpcEndpointsArgs']] vpc_endpoints: mapping of MwsVpcEndpoint for PrivateLink or Private Service Connect connections
         :param pulumi.Input[str] vpc_id: aws_vpc id
         :param pulumi.Input[str] vpc_status: (String) VPC attachment status
-        :param pulumi.Input[int] workspace_id: (Integer) id of associated workspace
+        :param pulumi.Input[str] workspace_id: (Integer) id of associated workspace
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
@@ -778,7 +778,7 @@ class MwsNetworks(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> pulumi.Output[int]:
+    def workspace_id(self) -> pulumi.Output[str]:
         """
         (Integer) id of associated workspace
         """

--- a/sdk/python/pulumi_databricks/mws_permission_assignment.py
+++ b/sdk/python/pulumi_databricks/mws_permission_assignment.py
@@ -16,14 +16,14 @@ class MwsPermissionAssignmentArgs:
     def __init__(__self__, *,
                  permissions: pulumi.Input[Sequence[pulumi.Input[str]]],
                  principal_id: pulumi.Input[int],
-                 workspace_id: pulumi.Input[int]):
+                 workspace_id: pulumi.Input[str]):
         """
         The set of arguments for constructing a MwsPermissionAssignment resource.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] permissions: The list of workspace permissions to assign to the principal:
                * `"USER"` - Can access the workspace with basic privileges.
                * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
         :param pulumi.Input[int] principal_id: Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
-        :param pulumi.Input[int] workspace_id: Databricks workspace ID.
+        :param pulumi.Input[str] workspace_id: Databricks workspace ID.
         """
         pulumi.set(__self__, "permissions", permissions)
         pulumi.set(__self__, "principal_id", principal_id)
@@ -57,14 +57,14 @@ class MwsPermissionAssignmentArgs:
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> pulumi.Input[int]:
+    def workspace_id(self) -> pulumi.Input[str]:
         """
         Databricks workspace ID.
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: pulumi.Input[int]):
+    def workspace_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "workspace_id", value)
 
 
@@ -73,14 +73,14 @@ class _MwsPermissionAssignmentState:
     def __init__(__self__, *,
                  permissions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  principal_id: Optional[pulumi.Input[int]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None):
+                 workspace_id: Optional[pulumi.Input[str]] = None):
         """
         Input properties used for looking up and filtering MwsPermissionAssignment resources.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] permissions: The list of workspace permissions to assign to the principal:
                * `"USER"` - Can access the workspace with basic privileges.
                * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
         :param pulumi.Input[int] principal_id: Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
-        :param pulumi.Input[int] workspace_id: Databricks workspace ID.
+        :param pulumi.Input[str] workspace_id: Databricks workspace ID.
         """
         if permissions is not None:
             pulumi.set(__self__, "permissions", permissions)
@@ -117,14 +117,14 @@ class _MwsPermissionAssignmentState:
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> Optional[pulumi.Input[int]]:
+    def workspace_id(self) -> Optional[pulumi.Input[str]]:
         """
         Databricks workspace ID.
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: Optional[pulumi.Input[int]]):
+    def workspace_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "workspace_id", value)
 
 
@@ -135,7 +135,7 @@ class MwsPermissionAssignment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  permissions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  principal_id: Optional[pulumi.Input[int]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None,
+                 workspace_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
         These resources are invoked in the account context. Permission Assignment Account API endpoints are restricted to account admins. Provider must have `account_id` attribute configured. Account Id that could be found in the top right corner of Accounts Console
@@ -206,7 +206,7 @@ class MwsPermissionAssignment(pulumi.CustomResource):
                * `"USER"` - Can access the workspace with basic privileges.
                * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
         :param pulumi.Input[int] principal_id: Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
-        :param pulumi.Input[int] workspace_id: Databricks workspace ID.
+        :param pulumi.Input[str] workspace_id: Databricks workspace ID.
         """
         ...
     @overload
@@ -294,7 +294,7 @@ class MwsPermissionAssignment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  permissions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  principal_id: Optional[pulumi.Input[int]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None,
+                 workspace_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -325,7 +325,7 @@ class MwsPermissionAssignment(pulumi.CustomResource):
             opts: Optional[pulumi.ResourceOptions] = None,
             permissions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
             principal_id: Optional[pulumi.Input[int]] = None,
-            workspace_id: Optional[pulumi.Input[int]] = None) -> 'MwsPermissionAssignment':
+            workspace_id: Optional[pulumi.Input[str]] = None) -> 'MwsPermissionAssignment':
         """
         Get an existing MwsPermissionAssignment resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.
@@ -337,7 +337,7 @@ class MwsPermissionAssignment(pulumi.CustomResource):
                * `"USER"` - Can access the workspace with basic privileges.
                * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
         :param pulumi.Input[int] principal_id: Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
-        :param pulumi.Input[int] workspace_id: Databricks workspace ID.
+        :param pulumi.Input[str] workspace_id: Databricks workspace ID.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
@@ -368,7 +368,7 @@ class MwsPermissionAssignment(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> pulumi.Output[int]:
+    def workspace_id(self) -> pulumi.Output[str]:
         """
         Databricks workspace ID.
         """

--- a/sdk/python/pulumi_databricks/mws_workspaces.py
+++ b/sdk/python/pulumi_databricks/mws_workspaces.py
@@ -38,7 +38,7 @@ class MwsWorkspacesArgs:
                  storage_configuration_id: Optional[pulumi.Input[str]] = None,
                  storage_customer_managed_key_id: Optional[pulumi.Input[str]] = None,
                  token: Optional[pulumi.Input['MwsWorkspacesTokenArgs']] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None,
+                 workspace_id: Optional[pulumi.Input[str]] = None,
                  workspace_status: Optional[pulumi.Input[str]] = None,
                  workspace_status_message: Optional[pulumi.Input[str]] = None,
                  workspace_url: Optional[pulumi.Input[str]] = None):
@@ -59,7 +59,7 @@ class MwsWorkspacesArgs:
         :param pulumi.Input[str] private_access_settings_id: Canonical unique identifier of MwsPrivateAccessSettings in Databricks Account.
         :param pulumi.Input[str] storage_configuration_id: `storage_configuration_id` from storage configuration.
         :param pulumi.Input[str] storage_customer_managed_key_id: `customer_managed_key_id` from customer managed keys with `use_cases` set to `STORAGE`. This is used to encrypt the DBFS Storage & Cluster Volumes.
-        :param pulumi.Input[int] workspace_id: (String) workspace id
+        :param pulumi.Input[str] workspace_id: (String) workspace id
         :param pulumi.Input[str] workspace_status: (String) workspace status
         :param pulumi.Input[str] workspace_status_message: (String) updates on workspace status
         :param pulumi.Input[str] workspace_url: (String) URL of the workspace
@@ -366,14 +366,14 @@ class MwsWorkspacesArgs:
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> Optional[pulumi.Input[int]]:
+    def workspace_id(self) -> Optional[pulumi.Input[str]]:
         """
         (String) workspace id
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: Optional[pulumi.Input[int]]):
+    def workspace_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "workspace_id", value)
 
     @property
@@ -437,7 +437,7 @@ class _MwsWorkspacesState:
                  storage_configuration_id: Optional[pulumi.Input[str]] = None,
                  storage_customer_managed_key_id: Optional[pulumi.Input[str]] = None,
                  token: Optional[pulumi.Input['MwsWorkspacesTokenArgs']] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None,
+                 workspace_id: Optional[pulumi.Input[str]] = None,
                  workspace_name: Optional[pulumi.Input[str]] = None,
                  workspace_status: Optional[pulumi.Input[str]] = None,
                  workspace_status_message: Optional[pulumi.Input[str]] = None,
@@ -458,7 +458,7 @@ class _MwsWorkspacesState:
         :param pulumi.Input[str] private_access_settings_id: Canonical unique identifier of MwsPrivateAccessSettings in Databricks Account.
         :param pulumi.Input[str] storage_configuration_id: `storage_configuration_id` from storage configuration.
         :param pulumi.Input[str] storage_customer_managed_key_id: `customer_managed_key_id` from customer managed keys with `use_cases` set to `STORAGE`. This is used to encrypt the DBFS Storage & Cluster Volumes.
-        :param pulumi.Input[int] workspace_id: (String) workspace id
+        :param pulumi.Input[str] workspace_id: (String) workspace id
         :param pulumi.Input[str] workspace_name: name of the workspace, will appear on UI.
         :param pulumi.Input[str] workspace_status: (String) workspace status
         :param pulumi.Input[str] workspace_status_message: (String) updates on workspace status
@@ -756,14 +756,14 @@ class _MwsWorkspacesState:
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> Optional[pulumi.Input[int]]:
+    def workspace_id(self) -> Optional[pulumi.Input[str]]:
         """
         (String) workspace id
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: Optional[pulumi.Input[int]]):
+    def workspace_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "workspace_id", value)
 
     @property
@@ -841,7 +841,7 @@ class MwsWorkspaces(pulumi.CustomResource):
                  storage_configuration_id: Optional[pulumi.Input[str]] = None,
                  storage_customer_managed_key_id: Optional[pulumi.Input[str]] = None,
                  token: Optional[pulumi.Input[pulumi.InputType['MwsWorkspacesTokenArgs']]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None,
+                 workspace_id: Optional[pulumi.Input[str]] = None,
                  workspace_name: Optional[pulumi.Input[str]] = None,
                  workspace_status: Optional[pulumi.Input[str]] = None,
                  workspace_status_message: Optional[pulumi.Input[str]] = None,
@@ -1043,7 +1043,7 @@ class MwsWorkspaces(pulumi.CustomResource):
         :param pulumi.Input[str] private_access_settings_id: Canonical unique identifier of MwsPrivateAccessSettings in Databricks Account.
         :param pulumi.Input[str] storage_configuration_id: `storage_configuration_id` from storage configuration.
         :param pulumi.Input[str] storage_customer_managed_key_id: `customer_managed_key_id` from customer managed keys with `use_cases` set to `STORAGE`. This is used to encrypt the DBFS Storage & Cluster Volumes.
-        :param pulumi.Input[int] workspace_id: (String) workspace id
+        :param pulumi.Input[str] workspace_id: (String) workspace id
         :param pulumi.Input[str] workspace_name: name of the workspace, will appear on UI.
         :param pulumi.Input[str] workspace_status: (String) workspace status
         :param pulumi.Input[str] workspace_status_message: (String) updates on workspace status
@@ -1271,7 +1271,7 @@ class MwsWorkspaces(pulumi.CustomResource):
                  storage_configuration_id: Optional[pulumi.Input[str]] = None,
                  storage_customer_managed_key_id: Optional[pulumi.Input[str]] = None,
                  token: Optional[pulumi.Input[pulumi.InputType['MwsWorkspacesTokenArgs']]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None,
+                 workspace_id: Optional[pulumi.Input[str]] = None,
                  workspace_name: Optional[pulumi.Input[str]] = None,
                  workspace_status: Optional[pulumi.Input[str]] = None,
                  workspace_status_message: Optional[pulumi.Input[str]] = None,
@@ -1348,7 +1348,7 @@ class MwsWorkspaces(pulumi.CustomResource):
             storage_configuration_id: Optional[pulumi.Input[str]] = None,
             storage_customer_managed_key_id: Optional[pulumi.Input[str]] = None,
             token: Optional[pulumi.Input[pulumi.InputType['MwsWorkspacesTokenArgs']]] = None,
-            workspace_id: Optional[pulumi.Input[int]] = None,
+            workspace_id: Optional[pulumi.Input[str]] = None,
             workspace_name: Optional[pulumi.Input[str]] = None,
             workspace_status: Optional[pulumi.Input[str]] = None,
             workspace_status_message: Optional[pulumi.Input[str]] = None,
@@ -1374,7 +1374,7 @@ class MwsWorkspaces(pulumi.CustomResource):
         :param pulumi.Input[str] private_access_settings_id: Canonical unique identifier of MwsPrivateAccessSettings in Databricks Account.
         :param pulumi.Input[str] storage_configuration_id: `storage_configuration_id` from storage configuration.
         :param pulumi.Input[str] storage_customer_managed_key_id: `customer_managed_key_id` from customer managed keys with `use_cases` set to `STORAGE`. This is used to encrypt the DBFS Storage & Cluster Volumes.
-        :param pulumi.Input[int] workspace_id: (String) workspace id
+        :param pulumi.Input[str] workspace_id: (String) workspace id
         :param pulumi.Input[str] workspace_name: name of the workspace, will appear on UI.
         :param pulumi.Input[str] workspace_status: (String) workspace status
         :param pulumi.Input[str] workspace_status_message: (String) updates on workspace status
@@ -1564,7 +1564,7 @@ class MwsWorkspaces(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> pulumi.Output[int]:
+    def workspace_id(self) -> pulumi.Output[str]:
         """
         (String) workspace id
         """


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-databricks/issues/55

This should fix the problem. The bridge has tests that demonstrate that strings don't loose information when converted to `int64` for the upstream provider.

I have been unable to build a full test that uses MetastoreAssignment. It's a non-trivial resource to instantiate.

BREAKING: Migration Guide

`workspace_id` has changed type from a `int` to `string`. Each call-site will need to be addressed. 