### PR TITLE
Fix schema and sdks

### DIFF
--- a/provider/cmd/pulumi-resource-databricks/bridge-metadata.json
+++ b/provider/cmd/pulumi-resource-databricks/bridge-metadata.json
@@ -6822,6 +6822,9 @@
             "databricks_metastore_assignment": [
                 "workspace_id"
             ],
+            "databricks_mws_ncc_binding": [
+                "workspace_id"
+            ],
             "databricks_mws_networks": [
                 "workspace_id"
             ],

--- a/provider/cmd/pulumi-resource-databricks/schema.json
+++ b/provider/cmd/pulumi-resource-databricks/schema.json
@@ -18818,7 +18818,7 @@
                     "description": "Canonical unique identifier of Network Connectivity Config in Databricks Account.\n"
                 },
                 "workspaceId": {
-                    "type": "integer",
+                    "type": "string",
                     "description": "Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.\n"
                 }
             },
@@ -18832,7 +18832,7 @@
                     "description": "Canonical unique identifier of Network Connectivity Config in Databricks Account.\n"
                 },
                 "workspaceId": {
-                    "type": "integer",
+                    "type": "string",
                     "description": "Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.\n",
                     "willReplaceOnChanges": true
                 }
@@ -18849,7 +18849,7 @@
                         "description": "Canonical unique identifier of Network Connectivity Config in Databricks Account.\n"
                     },
                     "workspaceId": {
-                        "type": "integer",
+                        "type": "string",
                         "description": "Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.\n",
                         "willReplaceOnChanges": true
                     }

--- a/sdk/dotnet/MwsNccBinding.cs
+++ b/sdk/dotnet/MwsNccBinding.cs
@@ -66,7 +66,7 @@ namespace Pulumi.Databricks
         /// Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
         /// </summary>
         [Output("workspaceId")]
-        public Output<int> WorkspaceId { get; private set; } = null!;
+        public Output<string> WorkspaceId { get; private set; } = null!;
 
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace Pulumi.Databricks
         /// Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
         /// </summary>
         [Input("workspaceId", required: true)]
-        public Input<int> WorkspaceId { get; set; } = null!;
+        public Input<string> WorkspaceId { get; set; } = null!;
 
         public MwsNccBindingArgs()
         {
@@ -144,7 +144,7 @@ namespace Pulumi.Databricks
         /// Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
         /// </summary>
         [Input("workspaceId")]
-        public Input<int>? WorkspaceId { get; set; }
+        public Input<string>? WorkspaceId { get; set; }
 
         public MwsNccBindingState()
         {

--- a/sdk/go/databricks/mwsNccBinding.go
+++ b/sdk/go/databricks/mwsNccBinding.go
@@ -72,7 +72,7 @@ type MwsNccBinding struct {
 	// Canonical unique identifier of Network Connectivity Config in Databricks Account.
 	NetworkConnectivityConfigId pulumi.StringOutput `pulumi:"networkConnectivityConfigId"`
 	// Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
-	WorkspaceId pulumi.IntOutput `pulumi:"workspaceId"`
+	WorkspaceId pulumi.StringOutput `pulumi:"workspaceId"`
 }
 
 // NewMwsNccBinding registers a new resource with the given unique name, arguments, and options.
@@ -114,14 +114,14 @@ type mwsNccBindingState struct {
 	// Canonical unique identifier of Network Connectivity Config in Databricks Account.
 	NetworkConnectivityConfigId *string `pulumi:"networkConnectivityConfigId"`
 	// Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
-	WorkspaceId *int `pulumi:"workspaceId"`
+	WorkspaceId *string `pulumi:"workspaceId"`
 }
 
 type MwsNccBindingState struct {
 	// Canonical unique identifier of Network Connectivity Config in Databricks Account.
 	NetworkConnectivityConfigId pulumi.StringPtrInput
 	// Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
-	WorkspaceId pulumi.IntPtrInput
+	WorkspaceId pulumi.StringPtrInput
 }
 
 func (MwsNccBindingState) ElementType() reflect.Type {
@@ -132,7 +132,7 @@ type mwsNccBindingArgs struct {
 	// Canonical unique identifier of Network Connectivity Config in Databricks Account.
 	NetworkConnectivityConfigId string `pulumi:"networkConnectivityConfigId"`
 	// Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
-	WorkspaceId int `pulumi:"workspaceId"`
+	WorkspaceId string `pulumi:"workspaceId"`
 }
 
 // The set of arguments for constructing a MwsNccBinding resource.
@@ -140,7 +140,7 @@ type MwsNccBindingArgs struct {
 	// Canonical unique identifier of Network Connectivity Config in Databricks Account.
 	NetworkConnectivityConfigId pulumi.StringInput
 	// Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
-	WorkspaceId pulumi.IntInput
+	WorkspaceId pulumi.StringInput
 }
 
 func (MwsNccBindingArgs) ElementType() reflect.Type {
@@ -236,8 +236,8 @@ func (o MwsNccBindingOutput) NetworkConnectivityConfigId() pulumi.StringOutput {
 }
 
 // Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
-func (o MwsNccBindingOutput) WorkspaceId() pulumi.IntOutput {
-	return o.ApplyT(func(v *MwsNccBinding) pulumi.IntOutput { return v.WorkspaceId }).(pulumi.IntOutput)
+func (o MwsNccBindingOutput) WorkspaceId() pulumi.StringOutput {
+	return o.ApplyT(func(v *MwsNccBinding) pulumi.StringOutput { return v.WorkspaceId }).(pulumi.StringOutput)
 }
 
 type MwsNccBindingArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/java/src/main/java/com/pulumi/databricks/MwsNccBinding.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/MwsNccBinding.java
@@ -10,7 +10,6 @@ import com.pulumi.core.internal.Codegen;
 import com.pulumi.databricks.MwsNccBindingArgs;
 import com.pulumi.databricks.Utilities;
 import com.pulumi.databricks.inputs.MwsNccBindingState;
-import java.lang.Integer;
 import java.lang.String;
 import javax.annotation.Nullable;
 
@@ -95,14 +94,14 @@ public class MwsNccBinding extends com.pulumi.resources.CustomResource {
      * Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
      * 
      */
-    @Export(name="workspaceId", refs={Integer.class}, tree="[0]")
-    private Output<Integer> workspaceId;
+    @Export(name="workspaceId", refs={String.class}, tree="[0]")
+    private Output<String> workspaceId;
 
     /**
      * @return Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
      * 
      */
-    public Output<Integer> workspaceId() {
+    public Output<String> workspaceId() {
         return this.workspaceId;
     }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/MwsNccBindingArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/MwsNccBindingArgs.java
@@ -6,7 +6,6 @@ package com.pulumi.databricks;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
-import java.lang.Integer;
 import java.lang.String;
 import java.util.Objects;
 
@@ -35,13 +34,13 @@ public final class MwsNccBindingArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="workspaceId", required=true)
-    private Output<Integer> workspaceId;
+    private Output<String> workspaceId;
 
     /**
      * @return Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
      * 
      */
-    public Output<Integer> workspaceId() {
+    public Output<String> workspaceId() {
         return this.workspaceId;
     }
 
@@ -97,7 +96,7 @@ public final class MwsNccBindingArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder workspaceId(Output<Integer> workspaceId) {
+        public Builder workspaceId(Output<String> workspaceId) {
             $.workspaceId = workspaceId;
             return this;
         }
@@ -108,7 +107,7 @@ public final class MwsNccBindingArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder workspaceId(Integer workspaceId) {
+        public Builder workspaceId(String workspaceId) {
             return workspaceId(Output.of(workspaceId));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/inputs/MwsNccBindingState.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/inputs/MwsNccBindingState.java
@@ -5,7 +5,6 @@ package com.pulumi.databricks.inputs;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
-import java.lang.Integer;
 import java.lang.String;
 import java.util.Objects;
 import java.util.Optional;
@@ -36,13 +35,13 @@ public final class MwsNccBindingState extends com.pulumi.resources.ResourceArgs 
      * 
      */
     @Import(name="workspaceId")
-    private @Nullable Output<Integer> workspaceId;
+    private @Nullable Output<String> workspaceId;
 
     /**
      * @return Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
      * 
      */
-    public Optional<Output<Integer>> workspaceId() {
+    public Optional<Output<String>> workspaceId() {
         return Optional.ofNullable(this.workspaceId);
     }
 
@@ -98,7 +97,7 @@ public final class MwsNccBindingState extends com.pulumi.resources.ResourceArgs 
          * @return builder
          * 
          */
-        public Builder workspaceId(@Nullable Output<Integer> workspaceId) {
+        public Builder workspaceId(@Nullable Output<String> workspaceId) {
             $.workspaceId = workspaceId;
             return this;
         }
@@ -109,7 +108,7 @@ public final class MwsNccBindingState extends com.pulumi.resources.ResourceArgs 
          * @return builder
          * 
          */
-        public Builder workspaceId(Integer workspaceId) {
+        public Builder workspaceId(String workspaceId) {
             return workspaceId(Output.of(workspaceId));
         }
 

--- a/sdk/nodejs/mwsNccBinding.ts
+++ b/sdk/nodejs/mwsNccBinding.ts
@@ -74,7 +74,7 @@ export class MwsNccBinding extends pulumi.CustomResource {
     /**
      * Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
      */
-    public readonly workspaceId!: pulumi.Output<number>;
+    public readonly workspaceId!: pulumi.Output<string>;
 
     /**
      * Create a MwsNccBinding resource with the given unique name, arguments, and options.
@@ -118,7 +118,7 @@ export interface MwsNccBindingState {
     /**
      * Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
      */
-    workspaceId?: pulumi.Input<number>;
+    workspaceId?: pulumi.Input<string>;
 }
 
 /**
@@ -132,5 +132,5 @@ export interface MwsNccBindingArgs {
     /**
      * Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
      */
-    workspaceId: pulumi.Input<number>;
+    workspaceId: pulumi.Input<string>;
 }

--- a/sdk/python/pulumi_databricks/mws_ncc_binding.py
+++ b/sdk/python/pulumi_databricks/mws_ncc_binding.py
@@ -15,11 +15,11 @@ __all__ = ['MwsNccBindingArgs', 'MwsNccBinding']
 class MwsNccBindingArgs:
     def __init__(__self__, *,
                  network_connectivity_config_id: pulumi.Input[str],
-                 workspace_id: pulumi.Input[int]):
+                 workspace_id: pulumi.Input[str]):
         """
         The set of arguments for constructing a MwsNccBinding resource.
         :param pulumi.Input[str] network_connectivity_config_id: Canonical unique identifier of Network Connectivity Config in Databricks Account.
-        :param pulumi.Input[int] workspace_id: Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
+        :param pulumi.Input[str] workspace_id: Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
         """
         pulumi.set(__self__, "network_connectivity_config_id", network_connectivity_config_id)
         pulumi.set(__self__, "workspace_id", workspace_id)
@@ -38,14 +38,14 @@ class MwsNccBindingArgs:
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> pulumi.Input[int]:
+    def workspace_id(self) -> pulumi.Input[str]:
         """
         Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: pulumi.Input[int]):
+    def workspace_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "workspace_id", value)
 
 
@@ -53,11 +53,11 @@ class MwsNccBindingArgs:
 class _MwsNccBindingState:
     def __init__(__self__, *,
                  network_connectivity_config_id: Optional[pulumi.Input[str]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None):
+                 workspace_id: Optional[pulumi.Input[str]] = None):
         """
         Input properties used for looking up and filtering MwsNccBinding resources.
         :param pulumi.Input[str] network_connectivity_config_id: Canonical unique identifier of Network Connectivity Config in Databricks Account.
-        :param pulumi.Input[int] workspace_id: Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
+        :param pulumi.Input[str] workspace_id: Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
         """
         if network_connectivity_config_id is not None:
             pulumi.set(__self__, "network_connectivity_config_id", network_connectivity_config_id)
@@ -78,14 +78,14 @@ class _MwsNccBindingState:
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> Optional[pulumi.Input[int]]:
+    def workspace_id(self) -> Optional[pulumi.Input[str]]:
         """
         Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
         """
         return pulumi.get(self, "workspace_id")
 
     @workspace_id.setter
-    def workspace_id(self, value: Optional[pulumi.Input[int]]):
+    def workspace_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "workspace_id", value)
 
 
@@ -95,7 +95,7 @@ class MwsNccBinding(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  network_connectivity_config_id: Optional[pulumi.Input[str]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None,
+                 workspace_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
         > **Note** Initialize provider with `alias = "account"`, `host = "https://accounts.azuredatabricks.net"` and use `provider = databricks.account` for all `databricks_mws_*` resources.
@@ -133,7 +133,7 @@ class MwsNccBinding(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] network_connectivity_config_id: Canonical unique identifier of Network Connectivity Config in Databricks Account.
-        :param pulumi.Input[int] workspace_id: Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
+        :param pulumi.Input[str] workspace_id: Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
         """
         ...
     @overload
@@ -190,7 +190,7 @@ class MwsNccBinding(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  network_connectivity_config_id: Optional[pulumi.Input[str]] = None,
-                 workspace_id: Optional[pulumi.Input[int]] = None,
+                 workspace_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -217,7 +217,7 @@ class MwsNccBinding(pulumi.CustomResource):
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
             network_connectivity_config_id: Optional[pulumi.Input[str]] = None,
-            workspace_id: Optional[pulumi.Input[int]] = None) -> 'MwsNccBinding':
+            workspace_id: Optional[pulumi.Input[str]] = None) -> 'MwsNccBinding':
         """
         Get an existing MwsNccBinding resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.
@@ -226,7 +226,7 @@ class MwsNccBinding(pulumi.CustomResource):
         :param pulumi.Input[str] id: The unique provider ID of the resource to lookup.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] network_connectivity_config_id: Canonical unique identifier of Network Connectivity Config in Databricks Account.
-        :param pulumi.Input[int] workspace_id: Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
+        :param pulumi.Input[str] workspace_id: Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
@@ -246,7 +246,7 @@ class MwsNccBinding(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="workspaceId")
-    def workspace_id(self) -> pulumi.Output[int]:
+    def workspace_id(self) -> pulumi.Output[str]:
         """
         Identifier of the workspace to attach the NCC to. Change forces creation of a new resource.
         """


### PR DESCRIPTION
c4ab6e0128f7a3c8db8b861bbf53f60e7ac66f3d merged after 163ac92f72e43e3361e7a4a0cdadf5d104c362a5 without a rebase. This resulted in a clean test run but a dirty schema after merging into master. This commit simply regenerates the schema and SDKs with `make tfgen build_sdks`.

Fixes #440