### PR TITLE
Mark `principle_id` as a string

### DIFF
--- a/provider/cmd/pulumi-resource-databricks/bridge-metadata.json
+++ b/provider/cmd/pulumi-resource-databricks/bridge-metadata.json
@@ -4331,6 +4331,16 @@
             }
         }
     },
+    "ids": {
+        "resources": {
+            "databricks_mws_permission_assignment": [
+                "principal_id"
+            ],
+            "databricks_permission_assignment": [
+                "principal_id"
+            ]
+        }
+    },
     "renames": {
         "resources": {
             "databricks:index/accessControlRuleSet:AccessControlRuleSet": "databricks_access_control_rule_set",

--- a/provider/cmd/pulumi-resource-databricks/schema.json
+++ b/provider/cmd/pulumi-resource-databricks/schema.json
@@ -20881,7 +20881,7 @@
                     "description": "The list of workspace permissions to assign to the principal:\n* `\"USER\"` - Can access the workspace with basic privileges.\n* `\"ADMIN\"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.\n"
                 },
                 "principalId": {
-                    "type": "integer",
+                    "type": "string",
                     "description": "Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, databricks.ServicePrincipal or databricks.Group data sources.\n"
                 },
                 "workspaceId": {
@@ -20904,7 +20904,7 @@
                     "willReplaceOnChanges": true
                 },
                 "principalId": {
-                    "type": "integer",
+                    "type": "string",
                     "description": "Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, databricks.ServicePrincipal or databricks.Group data sources.\n",
                     "willReplaceOnChanges": true
                 },
@@ -20931,7 +20931,7 @@
                         "willReplaceOnChanges": true
                     },
                     "principalId": {
-                        "type": "integer",
+                        "type": "string",
                         "description": "Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, databricks.ServicePrincipal or databricks.Group data sources.\n",
                         "willReplaceOnChanges": true
                     },
@@ -21902,7 +21902,7 @@
                     "description": "The list of workspace permissions to assign to the principal:\n* `\"USER\"` - Can access the workspace with basic privileges.\n* `\"ADMIN\"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.\n"
                 },
                 "principalId": {
-                    "type": "integer"
+                    "type": "string"
                 }
             },
             "required": [
@@ -21919,7 +21919,7 @@
                     "willReplaceOnChanges": true
                 },
                 "principalId": {
-                    "type": "integer",
+                    "type": "string",
                     "willReplaceOnChanges": true
                 }
             },
@@ -21939,7 +21939,7 @@
                         "willReplaceOnChanges": true
                     },
                     "principalId": {
-                        "type": "integer",
+                        "type": "string",
                         "willReplaceOnChanges": true
                     }
                 },

--- a/sdk/dotnet/MwsPermissionAssignment.cs
+++ b/sdk/dotnet/MwsPermissionAssignment.cs
@@ -132,7 +132,7 @@ namespace Pulumi.Databricks
         /// Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, databricks.ServicePrincipal or databricks.Group data sources.
         /// </summary>
         [Output("principalId")]
-        public Output<int> PrincipalId { get; private set; } = null!;
+        public Output<string> PrincipalId { get; private set; } = null!;
 
         /// <summary>
         /// Databricks workspace ID.
@@ -204,7 +204,7 @@ namespace Pulumi.Databricks
         /// Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, databricks.ServicePrincipal or databricks.Group data sources.
         /// </summary>
         [Input("principalId", required: true)]
-        public Input<int> PrincipalId { get; set; } = null!;
+        public Input<string> PrincipalId { get; set; } = null!;
 
         /// <summary>
         /// Databricks workspace ID.
@@ -238,7 +238,7 @@ namespace Pulumi.Databricks
         /// Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, databricks.ServicePrincipal or databricks.Group data sources.
         /// </summary>
         [Input("principalId")]
-        public Input<int>? PrincipalId { get; set; }
+        public Input<string>? PrincipalId { get; set; }
 
         /// <summary>
         /// Databricks workspace ID.

--- a/sdk/dotnet/PermissionAssignment.cs
+++ b/sdk/dotnet/PermissionAssignment.cs
@@ -139,7 +139,7 @@ namespace Pulumi.Databricks
         public Output<ImmutableArray<string>> Permissions { get; private set; } = null!;
 
         [Output("principalId")]
-        public Output<int> PrincipalId { get; private set; } = null!;
+        public Output<string> PrincipalId { get; private set; } = null!;
 
 
         /// <summary>
@@ -202,7 +202,7 @@ namespace Pulumi.Databricks
         }
 
         [Input("principalId", required: true)]
-        public Input<int> PrincipalId { get; set; } = null!;
+        public Input<string> PrincipalId { get; set; } = null!;
 
         public PermissionAssignmentArgs()
         {
@@ -227,7 +227,7 @@ namespace Pulumi.Databricks
         }
 
         [Input("principalId")]
-        public Input<int>? PrincipalId { get; set; }
+        public Input<string>? PrincipalId { get; set; }
 
         public PermissionAssignmentState()
         {

--- a/sdk/go/databricks/mwsPermissionAssignment.go
+++ b/sdk/go/databricks/mwsPermissionAssignment.go
@@ -150,7 +150,7 @@ type MwsPermissionAssignment struct {
 	// * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
 	Permissions pulumi.StringArrayOutput `pulumi:"permissions"`
 	// Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
-	PrincipalId pulumi.IntOutput `pulumi:"principalId"`
+	PrincipalId pulumi.StringOutput `pulumi:"principalId"`
 	// Databricks workspace ID.
 	WorkspaceId pulumi.StringOutput `pulumi:"workspaceId"`
 }
@@ -199,7 +199,7 @@ type mwsPermissionAssignmentState struct {
 	// * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
 	Permissions []string `pulumi:"permissions"`
 	// Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
-	PrincipalId *int `pulumi:"principalId"`
+	PrincipalId *string `pulumi:"principalId"`
 	// Databricks workspace ID.
 	WorkspaceId *string `pulumi:"workspaceId"`
 }
@@ -210,7 +210,7 @@ type MwsPermissionAssignmentState struct {
 	// * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
 	Permissions pulumi.StringArrayInput
 	// Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
-	PrincipalId pulumi.IntPtrInput
+	PrincipalId pulumi.StringPtrInput
 	// Databricks workspace ID.
 	WorkspaceId pulumi.StringPtrInput
 }
@@ -225,7 +225,7 @@ type mwsPermissionAssignmentArgs struct {
 	// * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
 	Permissions []string `pulumi:"permissions"`
 	// Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
-	PrincipalId int `pulumi:"principalId"`
+	PrincipalId string `pulumi:"principalId"`
 	// Databricks workspace ID.
 	WorkspaceId string `pulumi:"workspaceId"`
 }
@@ -237,7 +237,7 @@ type MwsPermissionAssignmentArgs struct {
 	// * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
 	Permissions pulumi.StringArrayInput
 	// Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
-	PrincipalId pulumi.IntInput
+	PrincipalId pulumi.StringInput
 	// Databricks workspace ID.
 	WorkspaceId pulumi.StringInput
 }
@@ -337,8 +337,8 @@ func (o MwsPermissionAssignmentOutput) Permissions() pulumi.StringArrayOutput {
 }
 
 // Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
-func (o MwsPermissionAssignmentOutput) PrincipalId() pulumi.IntOutput {
-	return o.ApplyT(func(v *MwsPermissionAssignment) pulumi.IntOutput { return v.PrincipalId }).(pulumi.IntOutput)
+func (o MwsPermissionAssignmentOutput) PrincipalId() pulumi.StringOutput {
+	return o.ApplyT(func(v *MwsPermissionAssignment) pulumi.StringOutput { return v.PrincipalId }).(pulumi.StringOutput)
 }
 
 // Databricks workspace ID.

--- a/sdk/go/databricks/permissionAssignment.go
+++ b/sdk/go/databricks/permissionAssignment.go
@@ -157,7 +157,7 @@ type PermissionAssignment struct {
 	// * `"USER"` - Can access the workspace with basic privileges.
 	// * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
 	Permissions pulumi.StringArrayOutput `pulumi:"permissions"`
-	PrincipalId pulumi.IntOutput         `pulumi:"principalId"`
+	PrincipalId pulumi.StringOutput      `pulumi:"principalId"`
 }
 
 // NewPermissionAssignment registers a new resource with the given unique name, arguments, and options.
@@ -200,7 +200,7 @@ type permissionAssignmentState struct {
 	// * `"USER"` - Can access the workspace with basic privileges.
 	// * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
 	Permissions []string `pulumi:"permissions"`
-	PrincipalId *int     `pulumi:"principalId"`
+	PrincipalId *string  `pulumi:"principalId"`
 }
 
 type PermissionAssignmentState struct {
@@ -208,7 +208,7 @@ type PermissionAssignmentState struct {
 	// * `"USER"` - Can access the workspace with basic privileges.
 	// * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
 	Permissions pulumi.StringArrayInput
-	PrincipalId pulumi.IntPtrInput
+	PrincipalId pulumi.StringPtrInput
 }
 
 func (PermissionAssignmentState) ElementType() reflect.Type {
@@ -220,7 +220,7 @@ type permissionAssignmentArgs struct {
 	// * `"USER"` - Can access the workspace with basic privileges.
 	// * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
 	Permissions []string `pulumi:"permissions"`
-	PrincipalId int      `pulumi:"principalId"`
+	PrincipalId string   `pulumi:"principalId"`
 }
 
 // The set of arguments for constructing a PermissionAssignment resource.
@@ -229,7 +229,7 @@ type PermissionAssignmentArgs struct {
 	// * `"USER"` - Can access the workspace with basic privileges.
 	// * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
 	Permissions pulumi.StringArrayInput
-	PrincipalId pulumi.IntInput
+	PrincipalId pulumi.StringInput
 }
 
 func (PermissionAssignmentArgs) ElementType() reflect.Type {
@@ -326,8 +326,8 @@ func (o PermissionAssignmentOutput) Permissions() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *PermissionAssignment) pulumi.StringArrayOutput { return v.Permissions }).(pulumi.StringArrayOutput)
 }
 
-func (o PermissionAssignmentOutput) PrincipalId() pulumi.IntOutput {
-	return o.ApplyT(func(v *PermissionAssignment) pulumi.IntOutput { return v.PrincipalId }).(pulumi.IntOutput)
+func (o PermissionAssignmentOutput) PrincipalId() pulumi.StringOutput {
+	return o.ApplyT(func(v *PermissionAssignment) pulumi.StringOutput { return v.PrincipalId }).(pulumi.StringOutput)
 }
 
 type PermissionAssignmentArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/java/src/main/java/com/pulumi/databricks/MwsPermissionAssignment.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/MwsPermissionAssignment.java
@@ -10,7 +10,6 @@ import com.pulumi.core.internal.Codegen;
 import com.pulumi.databricks.MwsPermissionAssignmentArgs;
 import com.pulumi.databricks.Utilities;
 import com.pulumi.databricks.inputs.MwsPermissionAssignmentState;
-import java.lang.Integer;
 import java.lang.String;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -193,14 +192,14 @@ public class MwsPermissionAssignment extends com.pulumi.resources.CustomResource
      * Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, databricks.ServicePrincipal or databricks.Group data sources.
      * 
      */
-    @Export(name="principalId", refs={Integer.class}, tree="[0]")
-    private Output<Integer> principalId;
+    @Export(name="principalId", refs={String.class}, tree="[0]")
+    private Output<String> principalId;
 
     /**
      * @return Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, databricks.ServicePrincipal or databricks.Group data sources.
      * 
      */
-    public Output<Integer> principalId() {
+    public Output<String> principalId() {
         return this.principalId;
     }
     /**

--- a/sdk/java/src/main/java/com/pulumi/databricks/MwsPermissionAssignmentArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/MwsPermissionAssignmentArgs.java
@@ -6,7 +6,6 @@ package com.pulumi.databricks;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
-import java.lang.Integer;
 import java.lang.String;
 import java.util.List;
 import java.util.Objects;
@@ -40,13 +39,13 @@ public final class MwsPermissionAssignmentArgs extends com.pulumi.resources.Reso
      * 
      */
     @Import(name="principalId", required=true)
-    private Output<Integer> principalId;
+    private Output<String> principalId;
 
     /**
      * @return Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, databricks.ServicePrincipal or databricks.Group data sources.
      * 
      */
-    public Output<Integer> principalId() {
+    public Output<String> principalId() {
         return this.principalId;
     }
 
@@ -134,7 +133,7 @@ public final class MwsPermissionAssignmentArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder principalId(Output<Integer> principalId) {
+        public Builder principalId(Output<String> principalId) {
             $.principalId = principalId;
             return this;
         }
@@ -145,7 +144,7 @@ public final class MwsPermissionAssignmentArgs extends com.pulumi.resources.Reso
          * @return builder
          * 
          */
-        public Builder principalId(Integer principalId) {
+        public Builder principalId(String principalId) {
             return principalId(Output.of(principalId));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/PermissionAssignment.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/PermissionAssignment.java
@@ -10,7 +10,6 @@ import com.pulumi.core.internal.Codegen;
 import com.pulumi.databricks.PermissionAssignmentArgs;
 import com.pulumi.databricks.Utilities;
 import com.pulumi.databricks.inputs.PermissionAssignmentState;
-import java.lang.Integer;
 import java.lang.String;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -195,10 +194,10 @@ public class PermissionAssignment extends com.pulumi.resources.CustomResource {
     public Output<List<String>> permissions() {
         return this.permissions;
     }
-    @Export(name="principalId", refs={Integer.class}, tree="[0]")
-    private Output<Integer> principalId;
+    @Export(name="principalId", refs={String.class}, tree="[0]")
+    private Output<String> principalId;
 
-    public Output<Integer> principalId() {
+    public Output<String> principalId() {
         return this.principalId;
     }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/PermissionAssignmentArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/PermissionAssignmentArgs.java
@@ -6,7 +6,6 @@ package com.pulumi.databricks;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
-import java.lang.Integer;
 import java.lang.String;
 import java.util.List;
 import java.util.Objects;
@@ -36,9 +35,9 @@ public final class PermissionAssignmentArgs extends com.pulumi.resources.Resourc
     }
 
     @Import(name="principalId", required=true)
-    private Output<Integer> principalId;
+    private Output<String> principalId;
 
-    public Output<Integer> principalId() {
+    public Output<String> principalId() {
         return this.principalId;
     }
 
@@ -104,12 +103,12 @@ public final class PermissionAssignmentArgs extends com.pulumi.resources.Resourc
             return permissions(List.of(permissions));
         }
 
-        public Builder principalId(Output<Integer> principalId) {
+        public Builder principalId(Output<String> principalId) {
             $.principalId = principalId;
             return this;
         }
 
-        public Builder principalId(Integer principalId) {
+        public Builder principalId(String principalId) {
             return principalId(Output.of(principalId));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/inputs/MwsPermissionAssignmentState.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/inputs/MwsPermissionAssignmentState.java
@@ -5,7 +5,6 @@ package com.pulumi.databricks.inputs;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
-import java.lang.Integer;
 import java.lang.String;
 import java.util.List;
 import java.util.Objects;
@@ -41,13 +40,13 @@ public final class MwsPermissionAssignmentState extends com.pulumi.resources.Res
      * 
      */
     @Import(name="principalId")
-    private @Nullable Output<Integer> principalId;
+    private @Nullable Output<String> principalId;
 
     /**
      * @return Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, databricks.ServicePrincipal or databricks.Group data sources.
      * 
      */
-    public Optional<Output<Integer>> principalId() {
+    public Optional<Output<String>> principalId() {
         return Optional.ofNullable(this.principalId);
     }
 
@@ -135,7 +134,7 @@ public final class MwsPermissionAssignmentState extends com.pulumi.resources.Res
          * @return builder
          * 
          */
-        public Builder principalId(@Nullable Output<Integer> principalId) {
+        public Builder principalId(@Nullable Output<String> principalId) {
             $.principalId = principalId;
             return this;
         }
@@ -146,7 +145,7 @@ public final class MwsPermissionAssignmentState extends com.pulumi.resources.Res
          * @return builder
          * 
          */
-        public Builder principalId(Integer principalId) {
+        public Builder principalId(String principalId) {
             return principalId(Output.of(principalId));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/databricks/inputs/PermissionAssignmentState.java
+++ b/sdk/java/src/main/java/com/pulumi/databricks/inputs/PermissionAssignmentState.java
@@ -5,7 +5,6 @@ package com.pulumi.databricks.inputs;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
-import java.lang.Integer;
 import java.lang.String;
 import java.util.List;
 import java.util.Objects;
@@ -37,9 +36,9 @@ public final class PermissionAssignmentState extends com.pulumi.resources.Resour
     }
 
     @Import(name="principalId")
-    private @Nullable Output<Integer> principalId;
+    private @Nullable Output<String> principalId;
 
-    public Optional<Output<Integer>> principalId() {
+    public Optional<Output<String>> principalId() {
         return Optional.ofNullable(this.principalId);
     }
 
@@ -105,12 +104,12 @@ public final class PermissionAssignmentState extends com.pulumi.resources.Resour
             return permissions(List.of(permissions));
         }
 
-        public Builder principalId(@Nullable Output<Integer> principalId) {
+        public Builder principalId(@Nullable Output<String> principalId) {
             $.principalId = principalId;
             return this;
         }
 
-        public Builder principalId(Integer principalId) {
+        public Builder principalId(String principalId) {
             return principalId(Output.of(principalId));
         }
 

--- a/sdk/nodejs/mwsPermissionAssignment.ts
+++ b/sdk/nodejs/mwsPermissionAssignment.ts
@@ -107,7 +107,7 @@ export class MwsPermissionAssignment extends pulumi.CustomResource {
     /**
      * Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, databricks.ServicePrincipal or databricks.Group data sources.
      */
-    public readonly principalId!: pulumi.Output<number>;
+    public readonly principalId!: pulumi.Output<string>;
     /**
      * Databricks workspace ID.
      */
@@ -162,7 +162,7 @@ export interface MwsPermissionAssignmentState {
     /**
      * Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, databricks.ServicePrincipal or databricks.Group data sources.
      */
-    principalId?: pulumi.Input<number>;
+    principalId?: pulumi.Input<string>;
     /**
      * Databricks workspace ID.
      */
@@ -182,7 +182,7 @@ export interface MwsPermissionAssignmentArgs {
     /**
      * Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, databricks.ServicePrincipal or databricks.Group data sources.
      */
-    principalId: pulumi.Input<number>;
+    principalId: pulumi.Input<string>;
     /**
      * Databricks workspace ID.
      */

--- a/sdk/nodejs/permissionAssignment.ts
+++ b/sdk/nodejs/permissionAssignment.ts
@@ -115,7 +115,7 @@ export class PermissionAssignment extends pulumi.CustomResource {
      * * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
      */
     public readonly permissions!: pulumi.Output<string[]>;
-    public readonly principalId!: pulumi.Output<number>;
+    public readonly principalId!: pulumi.Output<string>;
 
     /**
      * Create a PermissionAssignment resource with the given unique name, arguments, and options.
@@ -158,7 +158,7 @@ export interface PermissionAssignmentState {
      * * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
      */
     permissions?: pulumi.Input<pulumi.Input<string>[]>;
-    principalId?: pulumi.Input<number>;
+    principalId?: pulumi.Input<string>;
 }
 
 /**
@@ -171,5 +171,5 @@ export interface PermissionAssignmentArgs {
      * * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
      */
     permissions: pulumi.Input<pulumi.Input<string>[]>;
-    principalId: pulumi.Input<number>;
+    principalId: pulumi.Input<string>;
 }

--- a/sdk/python/pulumi_databricks/mws_permission_assignment.py
+++ b/sdk/python/pulumi_databricks/mws_permission_assignment.py
@@ -15,14 +15,14 @@ __all__ = ['MwsPermissionAssignmentArgs', 'MwsPermissionAssignment']
 class MwsPermissionAssignmentArgs:
     def __init__(__self__, *,
                  permissions: pulumi.Input[Sequence[pulumi.Input[str]]],
-                 principal_id: pulumi.Input[int],
+                 principal_id: pulumi.Input[str],
                  workspace_id: pulumi.Input[str]):
         """
         The set of arguments for constructing a MwsPermissionAssignment resource.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] permissions: The list of workspace permissions to assign to the principal:
                * `"USER"` - Can access the workspace with basic privileges.
                * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
-        :param pulumi.Input[int] principal_id: Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
+        :param pulumi.Input[str] principal_id: Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
         :param pulumi.Input[str] workspace_id: Databricks workspace ID.
         """
         pulumi.set(__self__, "permissions", permissions)
@@ -45,14 +45,14 @@ class MwsPermissionAssignmentArgs:
 
     @property
     @pulumi.getter(name="principalId")
-    def principal_id(self) -> pulumi.Input[int]:
+    def principal_id(self) -> pulumi.Input[str]:
         """
         Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
         """
         return pulumi.get(self, "principal_id")
 
     @principal_id.setter
-    def principal_id(self, value: pulumi.Input[int]):
+    def principal_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "principal_id", value)
 
     @property
@@ -72,14 +72,14 @@ class MwsPermissionAssignmentArgs:
 class _MwsPermissionAssignmentState:
     def __init__(__self__, *,
                  permissions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-                 principal_id: Optional[pulumi.Input[int]] = None,
+                 principal_id: Optional[pulumi.Input[str]] = None,
                  workspace_id: Optional[pulumi.Input[str]] = None):
         """
         Input properties used for looking up and filtering MwsPermissionAssignment resources.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] permissions: The list of workspace permissions to assign to the principal:
                * `"USER"` - Can access the workspace with basic privileges.
                * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
-        :param pulumi.Input[int] principal_id: Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
+        :param pulumi.Input[str] principal_id: Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
         :param pulumi.Input[str] workspace_id: Databricks workspace ID.
         """
         if permissions is not None:
@@ -105,14 +105,14 @@ class _MwsPermissionAssignmentState:
 
     @property
     @pulumi.getter(name="principalId")
-    def principal_id(self) -> Optional[pulumi.Input[int]]:
+    def principal_id(self) -> Optional[pulumi.Input[str]]:
         """
         Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
         """
         return pulumi.get(self, "principal_id")
 
     @principal_id.setter
-    def principal_id(self, value: Optional[pulumi.Input[int]]):
+    def principal_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "principal_id", value)
 
     @property
@@ -134,7 +134,7 @@ class MwsPermissionAssignment(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  permissions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-                 principal_id: Optional[pulumi.Input[int]] = None,
+                 principal_id: Optional[pulumi.Input[str]] = None,
                  workspace_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -205,7 +205,7 @@ class MwsPermissionAssignment(pulumi.CustomResource):
         :param pulumi.Input[Sequence[pulumi.Input[str]]] permissions: The list of workspace permissions to assign to the principal:
                * `"USER"` - Can access the workspace with basic privileges.
                * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
-        :param pulumi.Input[int] principal_id: Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
+        :param pulumi.Input[str] principal_id: Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
         :param pulumi.Input[str] workspace_id: Databricks workspace ID.
         """
         ...
@@ -293,7 +293,7 @@ class MwsPermissionAssignment(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  permissions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-                 principal_id: Optional[pulumi.Input[int]] = None,
+                 principal_id: Optional[pulumi.Input[str]] = None,
                  workspace_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
@@ -324,7 +324,7 @@ class MwsPermissionAssignment(pulumi.CustomResource):
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
             permissions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-            principal_id: Optional[pulumi.Input[int]] = None,
+            principal_id: Optional[pulumi.Input[str]] = None,
             workspace_id: Optional[pulumi.Input[str]] = None) -> 'MwsPermissionAssignment':
         """
         Get an existing MwsPermissionAssignment resource's state with the given name, id, and optional extra
@@ -336,7 +336,7 @@ class MwsPermissionAssignment(pulumi.CustomResource):
         :param pulumi.Input[Sequence[pulumi.Input[str]]] permissions: The list of workspace permissions to assign to the principal:
                * `"USER"` - Can access the workspace with basic privileges.
                * `"ADMIN"` - Can access the workspace and has workspace admin privileges to manage users and groups, workspace configurations, and more.
-        :param pulumi.Input[int] principal_id: Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
+        :param pulumi.Input[str] principal_id: Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
         :param pulumi.Input[str] workspace_id: Databricks workspace ID.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
@@ -360,7 +360,7 @@ class MwsPermissionAssignment(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="principalId")
-    def principal_id(self) -> pulumi.Output[int]:
+    def principal_id(self) -> pulumi.Output[str]:
         """
         Databricks ID of the user, service principal, or group. The principal ID can be retrieved using the SCIM API, or using databricks_user, ServicePrincipal or Group data sources.
         """

--- a/sdk/python/pulumi_databricks/permission_assignment.py
+++ b/sdk/python/pulumi_databricks/permission_assignment.py
@@ -15,7 +15,7 @@ __all__ = ['PermissionAssignmentArgs', 'PermissionAssignment']
 class PermissionAssignmentArgs:
     def __init__(__self__, *,
                  permissions: pulumi.Input[Sequence[pulumi.Input[str]]],
-                 principal_id: pulumi.Input[int]):
+                 principal_id: pulumi.Input[str]):
         """
         The set of arguments for constructing a PermissionAssignment resource.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] permissions: The list of workspace permissions to assign to the principal:
@@ -41,11 +41,11 @@ class PermissionAssignmentArgs:
 
     @property
     @pulumi.getter(name="principalId")
-    def principal_id(self) -> pulumi.Input[int]:
+    def principal_id(self) -> pulumi.Input[str]:
         return pulumi.get(self, "principal_id")
 
     @principal_id.setter
-    def principal_id(self, value: pulumi.Input[int]):
+    def principal_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "principal_id", value)
 
 
@@ -53,7 +53,7 @@ class PermissionAssignmentArgs:
 class _PermissionAssignmentState:
     def __init__(__self__, *,
                  permissions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-                 principal_id: Optional[pulumi.Input[int]] = None):
+                 principal_id: Optional[pulumi.Input[str]] = None):
         """
         Input properties used for looking up and filtering PermissionAssignment resources.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] permissions: The list of workspace permissions to assign to the principal:
@@ -81,11 +81,11 @@ class _PermissionAssignmentState:
 
     @property
     @pulumi.getter(name="principalId")
-    def principal_id(self) -> Optional[pulumi.Input[int]]:
+    def principal_id(self) -> Optional[pulumi.Input[str]]:
         return pulumi.get(self, "principal_id")
 
     @principal_id.setter
-    def principal_id(self, value: Optional[pulumi.Input[int]]):
+    def principal_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "principal_id", value)
 
 
@@ -95,7 +95,7 @@ class PermissionAssignment(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  permissions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-                 principal_id: Optional[pulumi.Input[int]] = None,
+                 principal_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
         These resources are invoked in the workspace context.
@@ -257,7 +257,7 @@ class PermissionAssignment(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  permissions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-                 principal_id: Optional[pulumi.Input[int]] = None,
+                 principal_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -284,7 +284,7 @@ class PermissionAssignment(pulumi.CustomResource):
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
             permissions: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-            principal_id: Optional[pulumi.Input[int]] = None) -> 'PermissionAssignment':
+            principal_id: Optional[pulumi.Input[str]] = None) -> 'PermissionAssignment':
         """
         Get an existing PermissionAssignment resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.
@@ -316,6 +316,6 @@ class PermissionAssignment(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="principalId")
-    def principal_id(self) -> pulumi.Output[int]:
+    def principal_id(self) -> pulumi.Output[str]:
         return pulumi.get(self, "principal_id")
 


### PR DESCRIPTION
Fixes #476 

Given that (1) this is a configuration fix and doesn't introduce new logic in the provider and (2) that creating a workspace to test against is nontrivial, I'd like to merge without a test here.