### PR TITLE
Fix typo: Match new `"id"` name to delegated ID field

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -184,7 +184,7 @@ func Provider() tfbridge.ProviderInfo {
 					"id": {Name: "monitorId"},
 				},
 				ComputeID: tfbridge.DelegateIDField(
-					"monitorID",
+					"monitorId",
 					"databricks",
 					"https://github.com/pulumi/pulumi-databricks",
 				),


### PR DESCRIPTION
Previously, we had:

```
 					"id": {Name: "monitorId"},
 				},
 				ComputeID: tfbridge.DelegateIDField(
 					"monitorID",
 					"databricks",
 					"https://github.com/pulumi/pulumi-databricks",
```

Note that the name assigned to `"id"` (`"monitorId"`) doesn't match the name of the field we told `tfbridge.DelegateIDField` to find the ID in (`"monitorID"`). These **must** match for `tfbridge.DelegateIDField` to work.

Fixes #669