### PR TITLE
Fix another delegated field typo

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -175,7 +175,7 @@ func Provider() tfbridge.ProviderInfo {
 					"id": {Name: "libraryId"},
 				},
 				ComputeID: tfbridge.DelegateIDField(
-					"libraryID",
+					"libraryId",
 					"databricks",
 					"https://github.com/pulumi/pulumi-databricks",
 				),


### PR DESCRIPTION
Similar to #669, this typo will cause panics on resource creation.