### PR TITLE
Opt into testProviderNeedsProviderBinary

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -9,6 +9,9 @@ env:
   DATABRICKS_HOST: https://accounts.cloud.databricks.com
 providerDefaultBranch: main
 makeTemplate: bridged
+# TestNoDebugLogsOnStartup loads the built provider plugin from ./bin, so the
+# fanout test_provider job must build the provider first. See pulumi/ci-mgmt#2336.
+testProviderNeedsProviderBinary: true
 allowMissingDocs: true
 pulumiConvert: 1
 registryDocs: true


### PR DESCRIPTION
Opt into `testProviderNeedsProviderBinary` so the fanout `test_provider` job builds the provider before running unit tests. `TestNoDebugLogsOnStartup` loads the provider plugin from `./bin`, which the split job no longer provides.

Depends on pulumi/ci-mgmt#2367, which adds the flag. The `run-acceptance-tests.yml` build step is added when ci-mgmt regenerates this repo after that merges, so this should merge after #2367.

Part of #1168

🤖 Generated with [Claude Code](https://claude.com/claude-code)
